### PR TITLE
fix triggers, give framework short name

### DIFF
--- a/config/luci-milo.cfg
+++ b/config/luci-milo.cfg
@@ -12,6 +12,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux"
     category: "Linux"
+    short_name: "frwk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux Engine"
@@ -26,6 +27,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Mac"
     category: "Mac"
+    short_name: "frwk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac Engine"
@@ -40,6 +42,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Windows"
     category: "Windows"
+    short_name: "frwk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows Engine"

--- a/config/luci-scheduler.cfg
+++ b/config/luci-scheduler.cfg
@@ -17,7 +17,7 @@ acl_sets {
 }
 
 trigger {
-  id: "master-gitiles-trigger"
+  id: "master-gitiles-trigger-framework"
   acl_sets: "default"
   gitiles: {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
@@ -25,14 +25,23 @@ trigger {
   }
 
   triggers: "Linux"
-  triggers: "Linux Engine"
   triggers: "Linux Flutter Packaging"
   triggers: "Mac"
-  triggers: "Mac Engine"
   triggers: "Mac Flutter Packaging"
   triggers: "Windows"
-  triggers: "Windows Engine"
   triggers: "Windows Flutter Packaging"
+}
+
+trigger {
+  id: "master-gitiles-trigger-engine"
+  acl_sets: "default"
+  gitiles: {
+    repo: "https://chromium.googlesource.com/external/github.com/flutter/engine"
+    refs: "refs/heads/master"
+  }
+  triggers: "Linux Engine"
+  triggers: "Mac Engine"
+  triggers: "Windows Engine"
 }
 
 job {


### PR DESCRIPTION
Right now the engine is getting triggered by flutter/flutter instead of flutter/engine

Also adds a short name for the framework.

I'm not 100% sure this will work - partly an experiment here.