### PR TITLE
Versions for ruby gems

### DIFF
--- a/config/cr-buildbucket.cfg
+++ b/config/cr-buildbucket.cfg
@@ -96,6 +96,7 @@ buckets {
       mixins: "linux"
       recipe {
         properties: "shard:coverage"
+        properties: "coveralls_lcov_version:1.5.1"
       }
     }
     builders {
@@ -114,6 +115,7 @@ buckets {
       mixins: "mac"
       recipe {
         properties: "shard:tests"
+        properties: "cocoapods_version:1.5.3"
         # see https://chrome-infra-packages.appspot.com/p/infra_internal/ios/xcode/mac/+/
         properties_j: "$depot_tools/osx_sdk:{\"sdk_version\": \"10b61\"}" # Xcode 10.1
       }


### PR DESCRIPTION
Property for Cocoapods version and Coveralls-lcov

Will be used by recipe to determine what version of the gem(s) to install.