### PR TITLE
Update recipe-deps-roller CIPD package

### DIFF
--- a/config/recipes_config.star
+++ b/config/recipes_config.star
@@ -71,7 +71,7 @@ def _setup():
             name="recipe_autoroller",
             cipd_package=
             "infra/recipe_bundles/chromium.googlesource.com/infra/infra",
-            cipd_version="git_revision:83c4abf53a0e73ca8b659766fbb0f7d46b05bd16"
+            cipd_version="git_revision:905c1df843d7771bf3adc0cf21f58eb9498ff063"
         ),
         execution_timeout=20 * time.minute,
         properties={


### PR DESCRIPTION
This version includes http://crrev.com/c/2256318, which is a reland of a
reverted CL that makes it safe to call `recipes.py dump_specs` in repos
where the command isn't supported yet.

Bug: fxbug.dev/54380