### PR TITLE
fix gitiles poller trigger for packaging builders

### DIFF
--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -34,7 +34,7 @@ def _setup(branches):
             platform_args,
             branch,
             branches[branch]["version"],
-            branches[branch]["ref"],
+            branches[branch]["testing-ref"],
         )
 
     engine_try_config(platform_args)

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -39,7 +39,7 @@ def _setup(branches):
             platfrom_args,
             branch,
             branches[branch]["version"],
-            branches[branch]["ref"],
+            branches[branch]["testing-ref"],
         )
 
     framework_try_config(platfrom_args)

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -610,7 +610,7 @@ consoles {
   id: "stable_packaging"
   name: "stable_packaging"
   repo_url: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  refs: "regexp:refs/heads/flutter-1\\.17-candidate\\.3"
+  refs: "regexp:refs/heads/stable"
   manifest_name: "REVISION"
   builders {
     name: "buildbucket/luci.flutter.prod/Linux Flutter Stable Packaging"
@@ -633,7 +633,7 @@ consoles {
   id: "beta_packaging"
   name: "beta_packaging"
   repo_url: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  refs: "regexp:refs/heads/flutter-1\\.19-candidate\\..+"
+  refs: "regexp:refs/heads/beta"
   manifest_name: "REVISION"
   builders {
     name: "buildbucket/luci.flutter.prod/Linux Flutter Beta Packaging"
@@ -656,7 +656,7 @@ consoles {
   id: "dev_packaging"
   name: "dev_packaging"
   repo_url: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  refs: "regexp:refs/heads/flutter-1\\.20-candidate\\..+"
+  refs: "regexp:refs/heads/dev"
   manifest_name: "REVISION"
   builders {
     name: "buildbucket/luci.flutter.prod/Linux Flutter Dev Packaging"

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -1263,15 +1263,23 @@ trigger {
 trigger {
   id: "beta-gitiles-trigger-framework"
   acl_sets: "prod"
-  triggers: "Linux Flutter Beta Packaging"
   triggers: "Linux beta"
-  triggers: "Mac Flutter Beta Packaging"
   triggers: "Mac beta"
-  triggers: "Windows Flutter Beta Packaging"
   triggers: "Windows beta"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/flutter-1\\.19-candidate\\..+"
+  }
+}
+trigger {
+  id: "beta-gitiles-trigger-packaging"
+  acl_sets: "prod"
+  triggers: "Linux Flutter Beta Packaging"
+  triggers: "Mac Flutter Beta Packaging"
+  triggers: "Windows Flutter Beta Packaging"
+  gitiles {
+    repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+    refs: "regexp:refs/heads/beta"
   }
 }
 trigger {
@@ -1300,15 +1308,23 @@ trigger {
 trigger {
   id: "dev-gitiles-trigger-framework"
   acl_sets: "prod"
-  triggers: "Linux Flutter Dev Packaging"
   triggers: "Linux dev"
-  triggers: "Mac Flutter Dev Packaging"
   triggers: "Mac dev"
-  triggers: "Windows Flutter Dev Packaging"
   triggers: "Windows dev"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/flutter-1\\.20-candidate\\..+"
+  }
+}
+trigger {
+  id: "dev-gitiles-trigger-packaging"
+  acl_sets: "prod"
+  triggers: "Linux Flutter Dev Packaging"
+  triggers: "Mac Flutter Dev Packaging"
+  triggers: "Windows Flutter Dev Packaging"
+  gitiles {
+    repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+    refs: "regexp:refs/heads/dev"
   }
 }
 trigger {
@@ -1444,15 +1460,23 @@ trigger {
 trigger {
   id: "stable-gitiles-trigger-framework"
   acl_sets: "prod"
-  triggers: "Linux Flutter Stable Packaging"
   triggers: "Linux stable"
-  triggers: "Mac Flutter Stable Packaging"
   triggers: "Mac stable"
-  triggers: "Windows Flutter Stable Packaging"
   triggers: "Windows stable"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/flutter-1\\.17-candidate\\.3"
+  }
+}
+trigger {
+  id: "stable-gitiles-trigger-packaging"
+  acl_sets: "prod"
+  triggers: "Linux Flutter Stable Packaging"
+  triggers: "Mac Flutter Stable Packaging"
+  triggers: "Windows Flutter Stable Packaging"
+  gitiles {
+    repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+    refs: "regexp:refs/heads/stable"
   }
 }
 acl_sets {

--- a/config/main.star
+++ b/config/main.star
@@ -51,7 +51,7 @@ BRANCHES = {
     },
     "master": {
         "testing-ref": r"refs/heads/master",
-        "release-ref": r"refs/heads/master",
+        "release-ref": None,
         "version": None,
     },
 }

--- a/config/main.star
+++ b/config/main.star
@@ -30,22 +30,28 @@ lucicfg.check_version("1.17.0")
 
 BRANCHES = {
     "stable": {
-        "ref": r"refs/heads/flutter-1\.17-candidate\.3",
+        # This ref is used to trigger testing
+        "testing-ref": r"refs/heads/flutter-1\.17-candidate\.3",
+        # This ref is used to trigger packaging builds
+        "release-ref": r"refs/heads/stable",
         # To be interpolated into recipe names e.g. 'flutter/flutter_' + BRANCHES['stable']['version']
         "version": "v1_17_0",
     },
     "beta": {
-        "ref": r"refs/heads/flutter-1\.19-candidate\..+",
+        "testing-ref": r"refs/heads/flutter-1\.19-candidate\..+",
+        "release-ref": r"refs/heads/beta",
         "version": None,
     },
     "dev": {
         # Don't match the last number of the branch name or else this will have
         # to be updated for every dev release.
-        "ref": r"refs/heads/flutter-1\.20-candidate\..+",
+        "testing-ref": r"refs/heads/flutter-1\.20-candidate\..+",
+        "release-ref": r"refs/heads/dev",
         "version": None,
     },
     "master": {
-        "ref": r"refs/heads/master",
+        "testing-ref": r"refs/heads/master",
+        "release-ref": r"refs/heads/master",
         "version": None,
     },
 }

--- a/config/packaging_config.star
+++ b/config/packaging_config.star
@@ -41,7 +41,7 @@ def _setup(branches):
             platform_args,
             branch,
             branches[branch]["version"],
-            branches[branch]["ref"],
+            branches[branch]["release-ref"],
         )
 
 def recipe_name(name, version):
@@ -83,7 +83,7 @@ def packaging_prod_config(platform_args, branch, version, ref):
     )
 
     # Defines prod schedulers
-    trigger_name = branch + "-gitiles-trigger-framework"
+    trigger_name = branch + "-gitiles-trigger-packaging"
     luci.gitiles_poller(
         name = trigger_name,
         bucket = "prod",

--- a/config/packaging_config.star
+++ b/config/packaging_config.star
@@ -34,7 +34,7 @@ def _setup(branches):
     packaging_recipe("ios-usb-dependencies", "")
     for branch in branches:
         # Skip packaging for master branch.
-        if branch == "master":
+        if branch == "master" or branch == None:
             continue
         packaging_recipe("flutter", branches[branch]["version"])
         packaging_prod_config(
@@ -71,7 +71,7 @@ def packaging_prod_config(platform_args, branch, version, ref):
     # Packaging should only build from release branches and never from master. This
     # is to prevent using excesive amount of resources to package something we will
     # never use.
-    if branch == "master":
+    if branch == "master" or branch == None:
         fail("Packaging builders should not run on master changes")
 
     # Defines console views for prod builders


### PR DESCRIPTION
1. Modified the `BRANCHES` dict to have two refs, `testing-ref` and `release-ref`.
2. Modify the packaging pollers to use `release-ref`, the rest to use `testing-ref`
3. Rename the packaging pollers to have `packaging` in the name, since I was running into lucicfg errors that look like `Error: luci.gitiles_poller("prod/stable-gitiles-trigger-framework") is redeclared, previous declaration:` and I didn't want to refactor further to share the pollers. This could be refactored later.