### PR TITLE
remove cap to max_batch_size for release builders, defaults to 1000

### DIFF
--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -157,7 +157,6 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         )
     else:
         triggering_policy = scheduler.greedy_batching(
-            max_batch_size = 1,
             max_concurrent_invocations = 3,
         )
 

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -141,7 +141,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -155,7 +154,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -169,7 +167,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -183,7 +180,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -197,7 +193,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -225,7 +220,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -239,7 +233,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -253,7 +246,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -267,7 +259,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -281,7 +272,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -309,7 +299,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -323,7 +312,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -337,7 +325,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -351,7 +338,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -365,7 +351,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -497,7 +482,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -511,7 +495,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -525,7 +508,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -539,7 +521,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -553,7 +534,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -567,7 +547,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -581,7 +560,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -609,7 +587,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -623,7 +600,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -637,7 +613,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -651,7 +626,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -665,7 +639,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -679,7 +652,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -693,7 +665,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -760,7 +731,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -774,7 +744,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -788,7 +757,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -802,7 +770,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -816,7 +783,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -830,7 +796,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -844,7 +809,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -963,7 +927,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -977,7 +940,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -991,7 +953,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -1019,7 +980,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -1033,7 +993,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -1047,7 +1006,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -1075,7 +1033,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -1089,7 +1046,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
@@ -1103,7 +1059,6 @@ job {
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
-    max_batch_size: 1
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"


### PR DESCRIPTION
When moving the branch that the gitiles poller watches, it will pick up a LOT of commits. No reason not to set the max_batch_size to 1000 (unless two releases were issued faster than the poller's interval, which seems unlikely). we already batch for packaging.