### PR TITLE
Update default os to Windows-Server for plugins windows tests

### DIFF
--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -8489,7 +8489,7 @@ buckets {
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
       dimensions: "cpu:x64"
-      dimensions: "os:Windows-10"
+      dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.try"
       recipe {
         name: "plugins/plugins"

--- a/config/plugins_config.star
+++ b/config/plugins_config.star
@@ -14,6 +14,7 @@ def _setup():
     platform_args = {
         "windows": {
             "caches": [swarming.cache(name = "pub_cache", path = ".pub-cache")],
+            "os": "Windows-Server",
         },
     }
     plugins_define_recipes()


### PR DESCRIPTION
Plugins repo is now supporting LUCI pre-submit windows test. But existing recipe is using default `Windows-10`, which fails the `flutter doctor` step: 

```
[X] Visual Studio - develop for Windows
    X Visual Studio not installed; this is necessary for Windows development.
```

This PR updates the os to `Windows-Server`, which works: 
https://logs.chromium.org/logs/flutter/led/stuartmorgan_google.com/8262c62e8def8247edb8e1e393a0f00077b60a9555dc8c7259f30762466019fb/+/steps/prepare_environment/0/steps/flutter_doctor/0/stdout

Related issue: 
https://github.com/flutter/flutter/issues/56143#issuecomment-687532941