### PR TITLE
Update cores to 32 for windows test in Plugins repo

### DIFF
--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -8487,7 +8487,7 @@ buckets {
     builders {
       name: "Windows Plugins"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:8"
+      dimensions: "cores:32"
       dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.try"

--- a/config/plugins_config.star
+++ b/config/plugins_config.star
@@ -15,6 +15,7 @@ def _setup():
         "windows": {
             "caches": [swarming.cache(name = "pub_cache", path = ".pub-cache")],
             "os": "Windows-Server",
+            "cores": "32",
         },
     }
     plugins_define_recipes()


### PR DESCRIPTION
This is a follow-up of https://github.com/flutter/infra/pull/201.

The default cores for windows builders are 8, however the cores for os `Windows-Server` bot are 32. We need to update to 32 to allow LUCI find corresponding bots.