### PR TITLE
[web] add new builders to run the new recipe

### DIFF
--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -221,6 +221,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         priority = 30 if branch == "master" else 25,
         **platform_args["linux"]
     )
+
     # Defines engine Linux builders
     common.linux_prod_builder(
         name = builder_name("Linux%s Host Engine|host", branch),

--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -74,6 +74,9 @@ def engine_properties(
         build_android_jit_release = False,
         no_bitcode = False,
         no_lto = False,
+        framework = False,
+        shard = "",
+        subshards = [],
         gcs_goldens_bucket = "",
         fuchsia_ctl_version = ""):
     """Creates build properties for engine based on parameters.
@@ -91,6 +94,9 @@ def engine_properties(
       build_android_jit_release(boolean): True if we need to build android jit release version.
       no_bitcode(boolean): True if we need to disable bit code.
       no_lto(boolean): True if we want to build all binaries without LTO.
+      framework(boolen): True if this build needs to use framework tests.
+      shard(str): Name of the shard that framework unit tests will be triggered for. Eg: web_tests
+      subshards(list): List of subshard names. Last one should have `_last` suffix. Eg: ["0", "1_last"],
       gcs_goldens_bucket: Bucket to upload failing golden tests' results for web engine.
       fuchsia_ctl_version(str): The version of the fuchsia controller to use.
 
@@ -121,6 +127,9 @@ def engine_properties(
         properties["jazzy_version"] = "0.9.5"
     if fuchsia_ctl_version:
         properties["fuchsia_ctl_version"] = fuchsia_ctl_version
+    if (framework):
+        properties["shard"] = shard
+        properties["subshards"] = subshards
     return properties
 
 def builder_name(pattern, branch):
@@ -198,7 +207,20 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         priority = 30 if branch == "master" else 25,
         **platform_args["windows"]
     )
-
+    common.linux_prod_builder(
+        name = builder_name("Linux%s Web Framework tests|web_tests", branch),
+        recipe = "engine/web_engine_framework",
+        properties = engine_properties(
+            framework = True,
+            shard = "web_tests",
+            subshards = ["0", "1", "2", "3", "4", "5", "6", "7_last"],
+        ),
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = 30 if branch == "master" else 25,
+        **platform_args["linux"]
+    )
     # Defines engine Linux builders
     common.linux_prod_builder(
         name = builder_name("Linux%s Host Engine|host", branch),
@@ -426,6 +448,19 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
         repo = repos.ENGINE,
         list_view_name = list_view_name,
         **platform_args["windows"]
+    )
+    common.linux_try_builder(
+        name = "Linux Web Framework tests|web_tests",
+        recipe = "engine/web_engine_framework",
+        repo = repos.ENGINE,
+        add_cq = True,
+        list_view_name = list_view_name,
+        properties = engine_properties(
+            framework = True,
+            shard = "web_tests",
+            subshards = ["0", "1", "2", "3", "4", "5", "6", "7_last"],
+        ),
+        **platform_args["linux"]
     )
 
     # Engine Linux try builders.

--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -53,7 +53,15 @@ def full_recipe_name(recipe_name, version):
 
 def engine_recipes(version):
     """Creates a luci recipe for a given code version."""
-    for name in ["engine", "web_engine", "engine_builder", "femu_test", "engine/scenarios"]:
+    recipe_list = [
+        "engine",
+        "web_engine",
+        "engine_builder",
+        "femu_test",
+        "engine/scenarios",
+        "engine/web_engine_framework",
+    ]
+    for name in recipe_list:
         luci.recipe(
             name = full_recipe_name(name, version),
             cipd_package =

--- a/config/generated/flutter/luci/commit-queue.cfg
+++ b/config/generated/flutter/luci/commit-queue.cfg
@@ -66,6 +66,9 @@ config_groups {
         name: "flutter/try/Linux Web Engine"
       }
       builders {
+        name: "flutter/try/Linux Web Framework tests"
+      }
+      builders {
         name: "flutter/try/Mac Host Engine"
       }
       retry_config {

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -433,6 +433,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux Web Framework tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_framework"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tests\""
+        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux analyze"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -772,6 +814,48 @@ buckets {
         properties_j: "gold_tryjob:false"
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 25
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux beta Web Framework tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_framework"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tests\""
+        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
         properties_j: "upload_packages:true"
       }
       priority: 25
@@ -2211,6 +2295,48 @@ buckets {
         properties_j: "gold_tryjob:false"
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 25
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux dev Web Framework tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_framework"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tests\""
+        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
         properties_j: "upload_packages:true"
       }
       priority: 25
@@ -4176,6 +4302,48 @@ buckets {
         properties_j: "gold_tryjob:false"
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 25
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux stable Web Framework tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_framework"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tests\""
+        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
         properties_j: "upload_packages:true"
       }
       priority: 25
@@ -15067,6 +15235,47 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "no_lto:true"
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux Web Framework tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "engine/web_engine_framework"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"\""
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tests\""
+        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 10800

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1062,6 +1062,11 @@ consoles {
     short_name: "wwe"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux stable Web Framework tests"
+    category: "Linux"
+    short_name: "web_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable Host Engine"
     category: "Linux"
     short_name: "host"
@@ -1148,6 +1153,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows beta Web Engine"
     category: "Windows"
     short_name: "wwe"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux beta Web Framework tests"
+    category: "Linux"
+    short_name: "web_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta Host Engine"
@@ -1238,6 +1248,11 @@ consoles {
     short_name: "wwe"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux dev Web Framework tests"
+    category: "Linux"
+    short_name: "web_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev Host Engine"
     category: "Linux"
     short_name: "host"
@@ -1326,6 +1341,11 @@ consoles {
     short_name: "wwe"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux Web Framework tests"
+    category: "Linux"
+    short_name: "web_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux Host Engine"
     category: "Linux"
     short_name: "host"
@@ -1403,6 +1423,9 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows Web Engine"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Linux Web Framework tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux Host Engine"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -110,6 +110,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux Web Framework tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux analyze"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -177,6 +188,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux beta Web Engine"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux beta Web Framework tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
   }
 }
@@ -551,6 +573,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev Web Engine"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux dev Web Framework tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
   }
 }
@@ -1068,6 +1101,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux stable Web Engine"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux stable Web Framework tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -128,6 +128,20 @@ job {
   }
 }
 job {
+  id: "Linux Web Framework tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux Web Framework tests"
+  }
+}
+job {
   id: "Linux analyze"
   acl_sets: "prod"
   triggering_policy {
@@ -217,6 +231,19 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux beta Web Engine"
+  }
+}
+job {
+  id: "Linux beta Web Framework tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux beta Web Framework tests"
   }
 }
 job {
@@ -687,6 +714,19 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev Web Engine"
+  }
+}
+job {
+  id: "Linux dev Web Framework tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux dev Web Framework tests"
   }
 }
 job {
@@ -1339,6 +1379,19 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux stable Web Engine"
+  }
+}
+job {
+  id: "Linux stable Web Framework tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux stable Web Framework tests"
   }
 }
 job {
@@ -4667,6 +4720,7 @@ trigger {
   triggers: "Linux beta Fuchsia FEMU"
   triggers: "Linux beta Host Engine"
   triggers: "Linux beta Web Engine"
+  triggers: "Linux beta Web Framework tests"
   triggers: "Mac beta Android AOT Engine"
   triggers: "Mac beta Android Debug Engine"
   triggers: "Mac beta Host Engine"
@@ -4781,6 +4835,7 @@ trigger {
   triggers: "Linux dev Fuchsia FEMU"
   triggers: "Linux dev Host Engine"
   triggers: "Linux dev Web Engine"
+  triggers: "Linux dev Web Framework tests"
   triggers: "Mac dev Android AOT Engine"
   triggers: "Mac dev Android Debug Engine"
   triggers: "Mac dev Host Engine"
@@ -4968,6 +5023,7 @@ trigger {
   triggers: "Linux Fuchsia FEMU"
   triggers: "Linux Host Engine"
   triggers: "Linux Web Engine"
+  triggers: "Linux Web Framework tests"
   triggers: "Mac Android AOT Engine"
   triggers: "Mac Android Debug Engine"
   triggers: "Mac Host Engine"
@@ -5071,6 +5127,7 @@ trigger {
   triggers: "Linux stable Fuchsia FEMU"
   triggers: "Linux stable Host Engine"
   triggers: "Linux stable Web Engine"
+  triggers: "Linux stable Web Framework tests"
   triggers: "Mac stable Android AOT Engine"
   triggers: "Mac stable Android Debug Engine"
   triggers: "Mac stable Host Engine"


### PR DESCRIPTION
Adding new try and prod builder to use the new recipe for running framework test with web engine. (Recipe: https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/engine/web_engine_framework.py)

Note: I got an error when running lucicfg:

```
luci.builder("try/Linux Web Framework tests") refers to undefined luci.executable("engine/web_engine_framework")
```

please let me know which steps I should take to add the new recipe to recupe_bundles CIPD package (or is it an automated process)

Fixes: https://github.com/flutter/flutter/issues/65052
 