### PR TITLE
Add deploy_gallery configs for both try and prod

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -278,14 +278,14 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
     )
 
     common.linux_prod_builder(
-        name = "Linux%s deploy_gallery|dg" % ("" if branch == "master" else " " + branch),
+        name = "Linux%s build_gallery|dg" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
         console_view_name = console_view_name,
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         properties = {
-            "validation": "deploy_gallery",
-            "validation_name": "Deploy gallery",
+            "validation": "build_gallery",
+            "validation_name": "Build gallery",
             "dependencies": [{"dependency": "android_sdk"}],
         },
         caches = [
@@ -451,14 +451,14 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
     )
 
     common.mac_prod_builder(
-        name = "Mac%s deploy_gallery|dg_test" % ("" if branch == "master" else " " + branch),
+        name = "Mac%s build_gallery|dg_test" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
         console_view_name = console_view_name,
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         properties = {
-            "validation": "deploy_gallery",
-            "validation_name": "Deploy gallery",
+            "validation": "build_gallery",
+            "validation_name": "Build gallery",
             "dependencies": [{"dependency": "xcode"}, {"dependency": "gems"}],
         },
         caches = [
@@ -644,13 +644,13 @@ def framework_try_config():
         ],
     )
     common.linux_try_builder(
-        name = "Linux deploy_gallery|dg",
+        name = "Linux build_gallery|dg",
         recipe = "flutter/flutter",
         repo = repos.FLUTTER,
         list_view_name = list_view_name,
         properties = {
-            "validation": "deploy_gallery",
-            "validation_name": "Deploy gallery",
+            "validation": "build_gallery",
+            "validation_name": "Build gallery",
             "dependencies": [{"dependency": "android_sdk"}],
         },
         caches = [
@@ -739,13 +739,13 @@ def framework_try_config():
     )
 
     common.mac_try_builder(
-        name = "Mac deploy_gallery|dg",
+        name = "Mac build_gallery|dg",
         recipe = "flutter/flutter",
         repo = repos.FLUTTER,
         list_view_name = list_view_name,
         properties = {
-            "validation": "deploy_gallery",
-            "validation_name": "Deploy gallery",
+            "validation": "build_gallery",
+            "validation_name": "Build gallery",
             "dependencies": [{"dependency": "xcode"}, {"dependency": "gems"}],
         },
         caches = [

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -277,6 +277,23 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         ],
     )
 
+    common.linux_prod_builder(
+        name = "Linux%s deploy_gallery|dg" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "validation": "deploy_gallery",
+            "validation_name": "Deploy gallery",
+            "dependencies": [{"dependency": "android_sdk"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+    )
+
     # Windows platform
     common.windows_prod_builder(
         name = "Windows%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
@@ -427,6 +444,22 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         properties = {
             "validation": "customer_testing",
             "validation_name": "Customer testing",
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+        ],
+    )
+
+    common.mac_prod_builder(
+        name = "Mac%s deploy_gallery|dg_test" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "validation": "deploy_gallery",
+            "validation_name": "Deploy gallery",
+            "dependencies": [{"dependency": "xcode"}, {"dependency": "gems"}],
         },
         caches = [
             swarming.cache(name = "pub_cache", path = ".pub_cache"),
@@ -618,7 +651,6 @@ def framework_try_config():
         properties = {
             "validation": "deploy_gallery",
             "validation_name": "Deploy gallery",
-            "secrets": {"ANDROID_GALLERY_UPLOAD_KEY": "android_gallery_upload_key.encrypted"},
             "dependencies": [{"dependency": "android_sdk"}],
         },
         caches = [
@@ -700,6 +732,21 @@ def framework_try_config():
         properties = {
             "validation": "customer_testing",
             "validation_name": "Customer testing",
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+        ],
+    )
+
+    common.mac_try_builder(
+        name = "Mac deploy_gallery|dg",
+        recipe = "flutter/flutter",
+        repo = repos.FLUTTER,
+        list_view_name = list_view_name,
+        properties = {
+            "validation": "deploy_gallery",
+            "validation_name": "Deploy gallery",
+            "dependencies": [{"dependency": "xcode"}, {"dependency": "gems"}],
         },
         caches = [
             swarming.cache(name = "pub_cache", path = ".pub_cache"),

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -947,6 +947,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux beta build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux beta build_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -1013,48 +1055,6 @@ buckets {
         properties_j: "validation_name:\"Customer testing\""
       }
       execution_timeout_secs: 10800
-      caches {
-        name: "flutter_openjdk_install"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux beta deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:8"
-      dimensions: "cpu:x64"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_22_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android29"
-      }
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2037,6 +2037,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux build_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -2103,48 +2145,6 @@ buckets {
         properties_j: "validation_name:\"Customer testing\""
       }
       execution_timeout_secs: 10800
-      caches {
-        name: "flutter_openjdk_install"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:8"
-      dimensions: "cpu:x64"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android29"
-      }
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2593,6 +2593,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux dev build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux dev build_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -2659,48 +2701,6 @@ buckets {
         properties_j: "validation_name:\"Customer testing\""
       }
       execution_timeout_secs: 10800
-      caches {
-        name: "flutter_openjdk_install"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux dev deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:8"
-      dimensions: "cpu:x64"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android29"
-      }
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4804,6 +4804,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux stable build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_20_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux stable build_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -4870,48 +4912,6 @@ buckets {
         properties_j: "validation_name:\"Customer testing\""
       }
       execution_timeout_secs: 10800
-      caches {
-        name: "flutter_openjdk_install"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux stable deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:8"
-      dimensions: "cpu:x64"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_20_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android29"
-      }
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -6744,6 +6744,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac beta build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac beta build_ios_framework_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -6854,47 +6895,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac beta deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_22_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {
@@ -7857,6 +7857,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac build_ios_framework_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -7967,47 +8008,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {
@@ -8340,6 +8340,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac dev build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac dev build_ios_framework_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -8450,47 +8491,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac dev deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {
@@ -10535,6 +10535,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac stable build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_20_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac stable build_ios_framework_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -10645,47 +10686,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac stable deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_20_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:true"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {
@@ -15981,6 +15981,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux build_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -16047,48 +16089,6 @@ buckets {
         properties_j: "validation_name:\"Customer testing\""
       }
       execution_timeout_secs: 10800
-      caches {
-        name: "flutter_openjdk_install"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:8"
-      dimensions: "cpu:x64"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:false"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android29"
-      }
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -17350,6 +17350,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac build_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+        properties_j: "validation:\"build_gallery\""
+        properties_j: "validation_name:\"Build gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac build_ios_framework_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -17460,47 +17501,6 @@ buckets {
         properties_j: "upload_packages:false"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      execution_timeout_secs: 10800
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac deploy_gallery"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "upload_packages:false"
-        properties_j: "validation:\"deploy_gallery\""
-        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -1026,6 +1026,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux beta deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux beta docs"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -2074,6 +2116,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux dev Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -2575,6 +2659,48 @@ buckets {
         properties_j: "validation_name:\"Customer testing\""
       }
       execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux dev deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4757,6 +4883,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux stable deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_20_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux stable docs"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -6705,6 +6873,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac beta deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac beta framework_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -7777,6 +7986,47 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac dev Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cpu:x64"
@@ -8200,6 +8450,47 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {
@@ -10354,6 +10645,47 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_20_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {
@@ -15748,7 +16080,6 @@ buckets {
         properties_j: "gold_tryjob:true"
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
-        properties_j: "secrets:{\"ANDROID_GALLERY_UPLOAD_KEY\":\"android_gallery_upload_key.encrypted\"}"
         properties_j: "upload_packages:false"
         properties_j: "validation:\"deploy_gallery\""
         properties_j: "validation_name:\"Deploy gallery\""
@@ -17129,6 +17460,47 @@ buckets {
         properties_j: "upload_packages:false"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac deploy_gallery"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11a420a\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"}]"
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+        properties_j: "validation:\"deploy_gallery\""
+        properties_j: "validation_name:\"Deploy gallery\""
       }
       execution_timeout_secs: 10800
       caches {

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1644,7 +1644,7 @@ consoles {
     short_name: "web_smk"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Linux stable build_gallery"
     category: "Linux"
     short_name: "dg"
   }
@@ -1689,7 +1689,7 @@ consoles {
     short_name: "cst_test"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac stable deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Mac stable build_gallery"
     category: "Mac"
     short_name: "dg_test"
   }
@@ -1757,7 +1757,7 @@ consoles {
     short_name: "web_smk"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Linux beta build_gallery"
     category: "Linux"
     short_name: "dg"
   }
@@ -1802,7 +1802,7 @@ consoles {
     short_name: "cst_test"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac beta deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Mac beta build_gallery"
     category: "Mac"
     short_name: "dg_test"
   }
@@ -1870,7 +1870,7 @@ consoles {
     short_name: "web_smk"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Linux dev build_gallery"
     category: "Linux"
     short_name: "dg"
   }
@@ -1915,7 +1915,7 @@ consoles {
     short_name: "cst_test"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac dev deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Mac dev build_gallery"
     category: "Mac"
     short_name: "dg_test"
   }
@@ -1978,7 +1978,7 @@ consoles {
     short_name: "web_smk"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Linux build_gallery"
     category: "Linux"
     short_name: "dg"
   }
@@ -2023,7 +2023,7 @@ consoles {
     short_name: "cst_test"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac deploy_gallery"
+    name: "buildbucket/luci.flutter.prod/Mac build_gallery"
     category: "Mac"
     short_name: "dg_test"
   }
@@ -2069,7 +2069,7 @@ consoles {
     name: "buildbucket/luci.flutter.try/Linux web_smoke_test"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Linux deploy_gallery"
+    name: "buildbucket/luci.flutter.try/Linux build_gallery"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac build_tests"
@@ -2087,7 +2087,7 @@ consoles {
     name: "buildbucket/luci.flutter.try/Mac customer_testing"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Mac deploy_gallery"
+    name: "buildbucket/luci.flutter.try/Mac build_gallery"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows build_tests"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1644,6 +1644,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux stable deploy_gallery"
+    category: "Linux"
+    short_name: "dg"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows stable build_tests"
     category: "Windows"
     short_name: "bld_tests"
@@ -1682,6 +1687,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac stable customer_testing"
     category: "Mac"
     short_name: "cst_test"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable deploy_gallery"
+    category: "Mac"
+    short_name: "dg_test"
   }
   favicon_url: "https://storage.googleapis.com/flutter_infra/favicon.ico"
 }
@@ -1747,6 +1757,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux beta deploy_gallery"
+    category: "Linux"
+    short_name: "dg"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows beta build_tests"
     category: "Windows"
     short_name: "bld_tests"
@@ -1785,6 +1800,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac beta customer_testing"
     category: "Mac"
     short_name: "cst_test"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta deploy_gallery"
+    category: "Mac"
+    short_name: "dg_test"
   }
   favicon_url: "https://storage.googleapis.com/flutter_infra/favicon.ico"
 }
@@ -1850,6 +1870,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux dev deploy_gallery"
+    category: "Linux"
+    short_name: "dg"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows dev build_tests"
     category: "Windows"
     short_name: "bld_tests"
@@ -1888,6 +1913,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac dev customer_testing"
     category: "Mac"
     short_name: "cst_test"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev deploy_gallery"
+    category: "Mac"
+    short_name: "dg_test"
   }
   favicon_url: "https://storage.googleapis.com/flutter_infra/favicon.ico"
 }
@@ -1948,6 +1978,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux deploy_gallery"
+    category: "Linux"
+    short_name: "dg"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows build_tests"
     category: "Windows"
     short_name: "bld_tests"
@@ -1986,6 +2021,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac customer_testing"
     category: "Mac"
     short_name: "cst_test"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac deploy_gallery"
+    category: "Mac"
+    short_name: "dg_test"
   }
   favicon_url: "https://storage.googleapis.com/flutter_infra/favicon.ico"
 }
@@ -2045,6 +2085,9 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac customer_testing"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Mac deploy_gallery"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows build_tests"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -253,6 +253,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux beta deploy_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux beta docs"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -539,6 +550,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux deploy_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux dev Android AOT Engine"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
   }
@@ -650,6 +672,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev customer_testing"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux dev deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1232,6 +1265,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux stable deploy_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux stable docs"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1705,6 +1749,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac beta deploy_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac beta framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1969,6 +2024,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac deploy_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac dev Android AOT Engine"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/engine"
   }
@@ -2047,6 +2113,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac dev customer_testing"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2553,6 +2630,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac stable customer_testing"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -231,6 +231,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux beta build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux beta build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -243,17 +254,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux beta customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux beta deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -528,6 +528,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -540,17 +551,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -660,6 +660,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux dev build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux dev build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -672,17 +683,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux dev deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1243,6 +1243,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux stable build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux stable build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1255,17 +1266,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux stable customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux stable deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1716,6 +1716,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac beta build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac beta build_ios_framework_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1739,17 +1750,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac beta customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac beta deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1991,6 +1991,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac build_ios_framework_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2014,17 +2025,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2090,6 +2090,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac dev build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac dev build_ios_framework_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2113,17 +2124,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac dev customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac dev deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2607,6 +2607,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac stable build_gallery"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac stable build_ios_framework_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2630,17 +2641,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac stable customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac stable deploy_gallery"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -303,6 +303,20 @@ job {
   }
 }
 job {
+  id: "Linux beta deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux beta deploy_gallery"
+  }
+}
+job {
   id: "Linux beta docs"
   acl_sets: "prod"
   triggering_policy {
@@ -667,6 +681,20 @@ job {
   }
 }
 job {
+  id: "Linux deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux deploy_gallery"
+  }
+}
+job {
   id: "Linux dev Android AOT Engine"
   acl_sets: "prod"
   triggering_policy {
@@ -811,6 +839,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev customer_testing"
+  }
+}
+job {
+  id: "Linux dev deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux dev deploy_gallery"
   }
 }
 job {
@@ -1535,6 +1577,20 @@ job {
   }
 }
 job {
+  id: "Linux stable deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux stable deploy_gallery"
+  }
+}
+job {
   id: "Linux stable docs"
   acl_sets: "prod"
   triggering_policy {
@@ -2130,6 +2186,20 @@ job {
   }
 }
 job {
+  id: "Mac beta deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta deploy_gallery"
+  }
+}
+job {
   id: "Mac beta framework_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -2463,6 +2533,20 @@ job {
   }
 }
 job {
+  id: "Mac deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac deploy_gallery"
+  }
+}
+job {
   id: "Mac dev Android AOT Engine"
   acl_sets: "prod"
   triggering_policy {
@@ -2568,6 +2652,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev customer_testing"
+  }
+}
+job {
+  id: "Mac dev deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev deploy_gallery"
   }
 }
 job {
@@ -3205,6 +3303,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac stable customer_testing"
+  }
+}
+job {
+  id: "Mac stable deploy_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable deploy_gallery"
   }
 }
 job {
@@ -4851,6 +4963,7 @@ trigger {
   triggers: "Linux beta analyze"
   triggers: "Linux beta build_tests"
   triggers: "Linux beta customer_testing"
+  triggers: "Linux beta deploy_gallery"
   triggers: "Linux beta docs"
   triggers: "Linux beta framework_tests"
   triggers: "Linux beta fuchsia_precache"
@@ -4860,6 +4973,7 @@ trigger {
   triggers: "Linux beta web_tests"
   triggers: "Mac beta build_tests"
   triggers: "Mac beta customer_testing"
+  triggers: "Mac beta deploy_gallery"
   triggers: "Mac beta framework_tests"
   triggers: "Mac beta tool_tests"
   triggers: "Windows beta build_tests"
@@ -4976,6 +5090,7 @@ trigger {
   triggers: "Linux dev analyze"
   triggers: "Linux dev build_tests"
   triggers: "Linux dev customer_testing"
+  triggers: "Linux dev deploy_gallery"
   triggers: "Linux dev docs"
   triggers: "Linux dev framework_tests"
   triggers: "Linux dev fuchsia_precache"
@@ -4985,6 +5100,7 @@ trigger {
   triggers: "Linux dev web_tests"
   triggers: "Mac dev build_tests"
   triggers: "Mac dev customer_testing"
+  triggers: "Mac dev deploy_gallery"
   triggers: "Mac dev framework_tests"
   triggers: "Mac dev tool_tests"
   triggers: "Windows dev build_tests"
@@ -5174,6 +5290,7 @@ trigger {
   triggers: "Linux analyze"
   triggers: "Linux build_tests"
   triggers: "Linux customer_testing"
+  triggers: "Linux deploy_gallery"
   triggers: "Linux docs"
   triggers: "Linux framework_tests"
   triggers: "Linux fuchsia_precache"
@@ -5183,6 +5300,7 @@ trigger {
   triggers: "Linux web_tests"
   triggers: "Mac build_tests"
   triggers: "Mac customer_testing"
+  triggers: "Mac deploy_gallery"
   triggers: "Mac framework_tests"
   triggers: "Mac tool_tests"
   triggers: "Windows build_tests"
@@ -5287,6 +5405,7 @@ trigger {
   triggers: "Linux stable analyze"
   triggers: "Linux stable build_tests"
   triggers: "Linux stable customer_testing"
+  triggers: "Linux stable deploy_gallery"
   triggers: "Linux stable docs"
   triggers: "Linux stable framework_tests"
   triggers: "Linux stable fuchsia_precache"
@@ -5296,6 +5415,7 @@ trigger {
   triggers: "Linux stable web_tests"
   triggers: "Mac stable build_tests"
   triggers: "Mac stable customer_testing"
+  triggers: "Mac stable deploy_gallery"
   triggers: "Mac stable framework_tests"
   triggers: "Mac stable tool_tests"
   triggers: "Windows stable build_tests"

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -275,6 +275,20 @@ job {
   }
 }
 job {
+  id: "Linux beta build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux beta build_gallery"
+  }
+}
+job {
   id: "Linux beta build_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -300,20 +314,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux beta customer_testing"
-  }
-}
-job {
-  id: "Linux beta deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta deploy_gallery"
   }
 }
 job {
@@ -653,6 +653,20 @@ job {
   }
 }
 job {
+  id: "Linux build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux build_gallery"
+  }
+}
+job {
   id: "Linux build_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -678,20 +692,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux customer_testing"
-  }
-}
-job {
-  id: "Linux deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux deploy_gallery"
   }
 }
 job {
@@ -814,6 +814,20 @@ job {
   }
 }
 job {
+  id: "Linux dev build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux dev build_gallery"
+  }
+}
+job {
   id: "Linux dev build_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -839,20 +853,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev customer_testing"
-  }
-}
-job {
-  id: "Linux dev deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev deploy_gallery"
   }
 }
 job {
@@ -1549,6 +1549,20 @@ job {
   }
 }
 job {
+  id: "Linux stable build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux stable build_gallery"
+  }
+}
+job {
   id: "Linux stable build_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -1574,20 +1588,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux stable customer_testing"
-  }
-}
-job {
-  id: "Linux stable deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable deploy_gallery"
   }
 }
 job {
@@ -2144,6 +2144,20 @@ job {
   }
 }
 job {
+  id: "Mac beta build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta build_gallery"
+  }
+}
+job {
   id: "Mac beta build_ios_framework_module_test"
   acl_sets: "prod"
   triggering_policy {
@@ -2183,20 +2197,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac beta customer_testing"
-  }
-}
-job {
-  id: "Mac beta deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac beta deploy_gallery"
   }
 }
 job {
@@ -2491,6 +2491,20 @@ job {
   }
 }
 job {
+  id: "Mac build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac build_gallery"
+  }
+}
+job {
   id: "Mac build_ios_framework_module_test"
   acl_sets: "prod"
   triggering_policy {
@@ -2530,20 +2544,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac customer_testing"
-  }
-}
-job {
-  id: "Mac deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac deploy_gallery"
   }
 }
 job {
@@ -2613,6 +2613,20 @@ job {
   }
 }
 job {
+  id: "Mac dev build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev build_gallery"
+  }
+}
+job {
   id: "Mac dev build_ios_framework_module_test"
   acl_sets: "prod"
   triggering_policy {
@@ -2652,20 +2666,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev customer_testing"
-  }
-}
-job {
-  id: "Mac dev deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac dev deploy_gallery"
   }
 }
 job {
@@ -3264,6 +3264,20 @@ job {
   }
 }
 job {
+  id: "Mac stable build_gallery"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable build_gallery"
+  }
+}
+job {
   id: "Mac stable build_ios_framework_module_test"
   acl_sets: "prod"
   triggering_policy {
@@ -3303,20 +3317,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac stable customer_testing"
-  }
-}
-job {
-  id: "Mac stable deploy_gallery"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac stable deploy_gallery"
   }
 }
 job {
@@ -4961,9 +4961,9 @@ trigger {
   id: "beta-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux beta analyze"
+  triggers: "Linux beta build_gallery"
   triggers: "Linux beta build_tests"
   triggers: "Linux beta customer_testing"
-  triggers: "Linux beta deploy_gallery"
   triggers: "Linux beta docs"
   triggers: "Linux beta framework_tests"
   triggers: "Linux beta fuchsia_precache"
@@ -4971,9 +4971,9 @@ trigger {
   triggers: "Linux beta web_integration_tests"
   triggers: "Linux beta web_smoke_test"
   triggers: "Linux beta web_tests"
+  triggers: "Mac beta build_gallery"
   triggers: "Mac beta build_tests"
   triggers: "Mac beta customer_testing"
-  triggers: "Mac beta deploy_gallery"
   triggers: "Mac beta framework_tests"
   triggers: "Mac beta tool_tests"
   triggers: "Windows beta build_tests"
@@ -5088,9 +5088,9 @@ trigger {
   id: "dev-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux dev analyze"
+  triggers: "Linux dev build_gallery"
   triggers: "Linux dev build_tests"
   triggers: "Linux dev customer_testing"
-  triggers: "Linux dev deploy_gallery"
   triggers: "Linux dev docs"
   triggers: "Linux dev framework_tests"
   triggers: "Linux dev fuchsia_precache"
@@ -5098,9 +5098,9 @@ trigger {
   triggers: "Linux dev web_integration_tests"
   triggers: "Linux dev web_smoke_test"
   triggers: "Linux dev web_tests"
+  triggers: "Mac dev build_gallery"
   triggers: "Mac dev build_tests"
   triggers: "Mac dev customer_testing"
-  triggers: "Mac dev deploy_gallery"
   triggers: "Mac dev framework_tests"
   triggers: "Mac dev tool_tests"
   triggers: "Windows dev build_tests"
@@ -5288,9 +5288,9 @@ trigger {
   id: "master-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux analyze"
+  triggers: "Linux build_gallery"
   triggers: "Linux build_tests"
   triggers: "Linux customer_testing"
-  triggers: "Linux deploy_gallery"
   triggers: "Linux docs"
   triggers: "Linux framework_tests"
   triggers: "Linux fuchsia_precache"
@@ -5298,9 +5298,9 @@ trigger {
   triggers: "Linux web_integration_tests"
   triggers: "Linux web_smoke_test"
   triggers: "Linux web_tests"
+  triggers: "Mac build_gallery"
   triggers: "Mac build_tests"
   triggers: "Mac customer_testing"
-  triggers: "Mac deploy_gallery"
   triggers: "Mac framework_tests"
   triggers: "Mac tool_tests"
   triggers: "Windows build_tests"
@@ -5403,9 +5403,9 @@ trigger {
   id: "stable-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux stable analyze"
+  triggers: "Linux stable build_gallery"
   triggers: "Linux stable build_tests"
   triggers: "Linux stable customer_testing"
-  triggers: "Linux stable deploy_gallery"
   triggers: "Linux stable docs"
   triggers: "Linux stable framework_tests"
   triggers: "Linux stable fuchsia_precache"
@@ -5413,9 +5413,9 @@ trigger {
   triggers: "Linux stable web_integration_tests"
   triggers: "Linux stable web_smoke_test"
   triggers: "Linux stable web_tests"
+  triggers: "Mac stable build_gallery"
   triggers: "Mac stable build_tests"
   triggers: "Mac stable customer_testing"
-  triggers: "Mac stable deploy_gallery"
   triggers: "Mac stable framework_tests"
   triggers: "Mac stable tool_tests"
   triggers: "Windows stable build_tests"


### PR DESCRIPTION
This PR adds corresponding try/prod configs for `deploy_gallery` test.

Related issue: https://github.com/flutter/flutter/issues/66707

Successful runs:
[linux try](https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/keyonghan_google.com/f02e76edf853f5b9bc72c494f6c4213163d5fe35c2a388e3b95688f4194e1fe2/+/annotations)
[mac try](https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/keyonghan_google.com/52ad853f8474b32f36e8acf1020fd031f25a1077fdc3880497186bf77e8a0a00/+/annotations)