### PR TITLE
adding web_e2e tests to framework tests

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -643,6 +643,8 @@ def framework_try_config():
             swarming.cache(name = "pub_cache", path = ".pub_cache"),
         ],
     )
+    # These tests are integration tests using integration_test (aka e2e)
+    # package.
     common.linux_try_builder(
         name = "Linux web_e2e_test|web_e2e",
         recipe = "flutter/flutter",

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -643,8 +643,6 @@ def framework_try_config():
             swarming.cache(name = "pub_cache", path = ".pub_cache"),
         ],
     )
-    # These tests are integration tests using integration_test (aka e2e)
-    # package.
     common.linux_try_builder(
         name = "Linux web_e2e_test|web_e2e",
         recipe = "flutter/flutter",

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -276,7 +276,21 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
             swarming.cache(name = "pub_cache", path = ".pub_cache"),
         ],
     )
-
+    common.linux_prod_builder(
+        name = "Linux%s web_e2e_test|web_e2e" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "validation": "web_e2e_test",
+            "validation_name": "Web e2e tests",
+            "dependencies": [{"dependency": "chrome_and_driver"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+        ],
+    )
     common.linux_prod_builder(
         name = "Linux%s build_gallery|dg" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
@@ -637,6 +651,20 @@ def framework_try_config():
         properties = {
             "validation": "web_smoke_test",
             "validation_name": "Web smoke tests",
+            "dependencies": [{"dependency": "chrome_and_driver"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+        ],
+    )
+    common.linux_try_builder(
+        name = "Linux web_e2e_test|web_e2e",
+        recipe = "flutter/flutter",
+        repo = repos.FLUTTER,
+        list_view_name = list_view_name,
+        properties = {
+            "validation": "web_e2e_test",
+            "validation_name": "Web e2e tests",
             "dependencies": [{"dependency": "chrome_and_driver"}],
         },
         caches = [

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -262,21 +262,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         ],
     )
     common.linux_prod_builder(
-        name = "Linux%s web_smoke_test|web_smk" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        properties = {
-            "validation": "web_smoke_test",
-            "validation_name": "Web smoke tests",
-            "dependencies": [{"dependency": "chrome_and_driver"}],
-        },
-        caches = [
-            swarming.cache(name = "pub_cache", path = ".pub_cache"),
-        ],
-    )
-    common.linux_prod_builder(
         name = "Linux%s web_e2e_test|web_e2e" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
         console_view_name = console_view_name,
@@ -285,6 +270,21 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         properties = {
             "validation": "web_e2e_test",
             "validation_name": "Web e2e tests",
+            "dependencies": [{"dependency": "chrome_and_driver"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+        ],
+    )
+    common.linux_prod_builder(
+        name = "Linux%s web_smoke_test|web_smk" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "validation": "web_smoke_test",
+            "validation_name": "Web smoke tests",
             "dependencies": [{"dependency": "chrome_and_driver"}],
         },
         caches = [
@@ -644,20 +644,6 @@ def framework_try_config():
         ],
     )
     common.linux_try_builder(
-        name = "Linux web_smoke_test|web_smk",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "validation": "web_smoke_test",
-            "validation_name": "Web smoke tests",
-            "dependencies": [{"dependency": "chrome_and_driver"}],
-        },
-        caches = [
-            swarming.cache(name = "pub_cache", path = ".pub_cache"),
-        ],
-    )
-    common.linux_try_builder(
         name = "Linux web_e2e_test|web_e2e",
         recipe = "flutter/flutter",
         repo = repos.FLUTTER,
@@ -665,6 +651,20 @@ def framework_try_config():
         properties = {
             "validation": "web_e2e_test",
             "validation_name": "Web e2e tests",
+            "dependencies": [{"dependency": "chrome_and_driver"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+        ],
+    )
+    common.linux_try_builder(
+        name = "Linux web_smoke_test|web_smk",
+        recipe = "flutter/flutter",
+        repo = repos.FLUTTER,
+        list_view_name = list_view_name,
+        properties = {
+            "validation": "web_smoke_test",
+            "validation_name": "Web smoke tests",
             "dependencies": [{"dependency": "chrome_and_driver"}],
         },
         caches = [

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -1878,6 +1878,44 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux beta web_e2e_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"chrome_and_driver\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"web_e2e_test\""
+        properties_j: "validation_name:\"Web e2e tests\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux beta web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -3511,6 +3549,44 @@ buckets {
         name: "android_sdk"
         path: "android29"
       }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux dev web_e2e_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"chrome_and_driver\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"web_e2e_test\""
+        properties_j: "validation_name:\"Web e2e tests\""
+      }
+      execution_timeout_secs: 10800
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5735,6 +5811,44 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux stable web_e2e_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_20_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"chrome_and_driver\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"web_e2e_test\""
+        properties_j: "validation_name:\"Web e2e tests\""
+      }
+      execution_timeout_secs: 10800
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux stable web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -5923,6 +6037,44 @@ buckets {
         name: "android_sdk"
         path: "android29"
       }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux web_e2e_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"chrome_and_driver\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+        properties_j: "validation:\"web_e2e_test\""
+        properties_j: "validation_name:\"Web e2e tests\""
+      }
+      execution_timeout_secs: 10800
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -16899,6 +17051,44 @@ buckets {
         name: "android_sdk"
         path: "android29"
       }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux web_e2e_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"chrome_and_driver\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+        properties_j: "validation:\"web_e2e_test\""
+        properties_j: "validation_name:\"Web e2e tests\""
+      }
+      execution_timeout_secs: 10800
       caches {
         name: "flutter_openjdk_install"
         path: "java"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1639,14 +1639,14 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_e2e_test"
     category: "Linux"
     short_name: "web_e2e"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux stable web_smoke_test"
+    category: "Linux"
+    short_name: "web_smk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable build_gallery"
@@ -1757,14 +1757,14 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_e2e_test"
     category: "Linux"
     short_name: "web_e2e"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux beta web_smoke_test"
+    category: "Linux"
+    short_name: "web_smk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta build_gallery"
@@ -1875,14 +1875,14 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_e2e_test"
     category: "Linux"
     short_name: "web_e2e"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux dev web_smoke_test"
+    category: "Linux"
+    short_name: "web_smk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev build_gallery"
@@ -1988,14 +1988,14 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux web_e2e_test"
     category: "Linux"
     short_name: "web_e2e"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux web_smoke_test"
+    category: "Linux"
+    short_name: "web_smk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux build_gallery"
@@ -2086,10 +2086,10 @@ consoles {
     name: "buildbucket/luci.flutter.try/Linux fuchsia_precache"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Linux web_smoke_test"
+    name: "buildbucket/luci.flutter.try/Linux web_e2e_test"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Linux web_e2e_test"
+    name: "buildbucket/luci.flutter.try/Linux web_smoke_test"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux build_gallery"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1644,6 +1644,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux stable web_e2e_test"
+    category: "Linux"
+    short_name: "web_e2e"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable build_gallery"
     category: "Linux"
     short_name: "dg"
@@ -1755,6 +1760,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta web_smoke_test"
     category: "Linux"
     short_name: "web_smk"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux beta web_e2e_test"
+    category: "Linux"
+    short_name: "web_e2e"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta build_gallery"
@@ -1870,6 +1880,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux dev web_e2e_test"
+    category: "Linux"
+    short_name: "web_e2e"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev build_gallery"
     category: "Linux"
     short_name: "dg"
@@ -1978,6 +1993,11 @@ consoles {
     short_name: "web_smk"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux web_e2e_test"
+    category: "Linux"
+    short_name: "web_e2e"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux build_gallery"
     category: "Linux"
     short_name: "dg"
@@ -2067,6 +2087,9 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_smoke_test"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Linux web_e2e_test"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux build_gallery"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -484,6 +484,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux beta web_e2e_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux beta web_integration_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -903,6 +914,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev web_benchmarks_html"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux dev web_e2e_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1496,6 +1518,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux stable web_e2e_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux stable web_integration_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1541,6 +1574,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux web_benchmarks_html"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux web_e2e_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -597,6 +597,20 @@ job {
   }
 }
 job {
+  id: "Linux beta web_e2e_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux beta web_e2e_test"
+  }
+}
+job {
   id: "Linux beta web_integration_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -1133,6 +1147,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev web_benchmarks_html"
+  }
+}
+job {
+  id: "Linux dev web_e2e_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux dev web_e2e_test"
   }
 }
 job {
@@ -1871,6 +1899,20 @@ job {
   }
 }
 job {
+  id: "Linux stable web_e2e_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux stable web_e2e_test"
+  }
+}
+job {
   id: "Linux stable web_integration_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -1938,6 +1980,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux web_benchmarks_html"
+  }
+}
+job {
+  id: "Linux web_e2e_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux web_e2e_test"
   }
 }
 job {
@@ -4968,6 +5024,7 @@ trigger {
   triggers: "Linux beta framework_tests"
   triggers: "Linux beta fuchsia_precache"
   triggers: "Linux beta tool_tests"
+  triggers: "Linux beta web_e2e_test"
   triggers: "Linux beta web_integration_tests"
   triggers: "Linux beta web_smoke_test"
   triggers: "Linux beta web_tests"
@@ -5095,6 +5152,7 @@ trigger {
   triggers: "Linux dev framework_tests"
   triggers: "Linux dev fuchsia_precache"
   triggers: "Linux dev tool_tests"
+  triggers: "Linux dev web_e2e_test"
   triggers: "Linux dev web_integration_tests"
   triggers: "Linux dev web_smoke_test"
   triggers: "Linux dev web_tests"
@@ -5295,6 +5353,7 @@ trigger {
   triggers: "Linux framework_tests"
   triggers: "Linux fuchsia_precache"
   triggers: "Linux tool_tests"
+  triggers: "Linux web_e2e_test"
   triggers: "Linux web_integration_tests"
   triggers: "Linux web_smoke_test"
   triggers: "Linux web_tests"
@@ -5410,6 +5469,7 @@ trigger {
   triggers: "Linux stable framework_tests"
   triggers: "Linux stable fuchsia_precache"
   triggers: "Linux stable tool_tests"
+  triggers: "Linux stable web_e2e_test"
   triggers: "Linux stable web_integration_tests"
   triggers: "Linux stable web_smoke_test"
   triggers: "Linux stable web_tests"


### PR DESCRIPTION
There are no tests in the flutter/flutter repo right now that tests the integration_test packages usage with flutter drive on web. Current driver tests does not cover integration_test package. This created a P0 this week. 

This new builders will use these tests: https://github.com/flutter/flutter/tree/master/dev/integration_tests/web_e2e_tests
Related recipe side code: https://flutter.googlesource.com/recipes/+/6c48adc977b231b55dfeb7937f290c7f610931d2

Related: https://github.com/flutter/flutter/issues/67560