### PR TITLE
Remove cores dimension for plugins windows builder

### DIFF
--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -16228,7 +16228,6 @@ buckets {
     builders {
       name: "Windows Plugins"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:32"
       dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.try"

--- a/config/plugins_config.star
+++ b/config/plugins_config.star
@@ -15,7 +15,6 @@ def _setup():
         "windows": {
             "caches": [swarming.cache(name = "pub_cache", path = ".pub-cache")],
             "os": "Windows-Server",
-            "cores": "32",
         },
     }
     plugins_define_recipes()


### PR DESCRIPTION
Windows server bots in luci pool are now all of 8 cores. This PR is to remove the 32 cores dimension requirement to bring the plugins Windows builder back.

Related issue: https://github.com/flutter/flutter/issues/69232