### PR TITLE
Shorten web_long_running_tests -> web_lrt

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -196,7 +196,7 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         ],
     )
     common.linux_prod_builder(
-        name = "Linux%s web_long_running_tests|web_long_running_tests" % ("" if branch == "master" else " " + branch),
+        name = "Linux%s web_long_running_tests|web_lrt" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
         console_view_name = console_view_name,
         triggered_by = [trigger_name],
@@ -576,7 +576,7 @@ def framework_try_config():
         ],
     )
     common.linux_try_builder(
-        name = "Linux web_long_running_tests|web_long_running_tests",
+        name = "Linux web_long_running_tests|web_lrt",
         recipe = "flutter/flutter",
         repo = repos.FLUTTER,
         list_view_name = list_view_name,

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1348,7 +1348,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests"
     category: "Linux"
-    short_name: "web_long_running_tests"
+    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable analyze"
@@ -1471,7 +1471,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests"
     category: "Linux"
-    short_name: "web_long_running_tests"
+    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta analyze"
@@ -1594,7 +1594,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests"
     category: "Linux"
-    short_name: "web_long_running_tests"
+    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev analyze"
@@ -1712,7 +1712,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests"
     category: "Linux"
-    short_name: "web_long_running_tests"
+    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux analyze"


### PR DESCRIPTION
Otherwise, it's taking an unfair amount of horizontal space:

![web_long_running_test_console](https://user-images.githubusercontent.com/211513/97729904-678f7600-1a90-11eb-8319-af24861d70dc.png)
