### PR TITLE
Add web_tool_tests builders

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -165,6 +165,22 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         ],
     )
     common.linux_prod_builder(
+        name = "Linux%s web_tool_tests|web_tool_tests" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "shard": "web_tool_tests",
+            "subshards": ["web"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+    )
+    common.linux_prod_builder(
         name = "Linux%s web_integration_tests|web_int" % ("" if branch == "master" else " " + branch),
         recipe = "flutter/flutter_drone",
         console_view_name = console_view_name,
@@ -381,6 +397,23 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = "Windows-Server",
     )
     common.windows_prod_builder(
+        name = "Windows%s web_tool_tests|web_tool_tests" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "shard": "web_tool_tests",
+            "subshards": ["web"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+        os = "Windows-Server",
+    )
+    common.windows_prod_builder(
         name = "Windows%s SDK Drone|frwdrn" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
         console_view_name = None,
@@ -453,6 +486,25 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         properties = {
             "shard": "tool_tests",
             "subshards": ["general", "commands", "integration"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "goldctl"}],
+            "$depot_tools/osx_sdk": {
+                "sdk_version": "11E708",
+            },
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+    )
+    common.mac_prod_builder(
+        name = "Mac%s web_tool_tests|web_tool_tests" % ("" if branch == "master" else " " + branch),
+        recipe = new_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        properties = {
+            "shard": "web_tool_tests",
+            "subshards": ["web"],
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "goldctl"}],
             "$depot_tools/osx_sdk": {
                 "sdk_version": "11E708",
@@ -557,6 +609,22 @@ def framework_try_config():
         properties = {
             "shard": "tool_tests",
             "subshards": ["general", "commands", "integration"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+    )
+    common.linux_try_builder(
+        name = "Linux web_tool_tests|web_tool_tests",
+        recipe = "flutter/flutter",
+        repo = repos.FLUTTER,
+        add_cq = True,
+        list_view_name = list_view_name,
+        properties = {
+            "shard": "web_tool_tests",
+            "subshards": ["web"],
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
         },
         caches = [
@@ -780,6 +848,25 @@ def framework_try_config():
         ],
     )
     common.mac_try_builder(
+        name = "Mac web_tool_tests|web_tool_tests",
+        recipe = "flutter/flutter",
+        repo = repos.FLUTTER,
+        add_cq = True,
+        list_view_name = list_view_name,
+        properties = {
+            "shard": "web_tool_tests",
+            "subshards": ["web"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "goldctl"}],
+            "$depot_tools/osx_sdk": {
+                "sdk_version": "11E708",
+            },
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+    )
+    common.mac_try_builder(
         name = "Mac SDK Drone|frwkdrn",
         recipe = "flutter/flutter_drone",
         repo = repos.FLUTTER,
@@ -862,6 +949,23 @@ def framework_try_config():
         properties = {
             "shard": "tool_tests",
             "subshards": ["general", "commands", "integration"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
+        },
+        caches = [
+            swarming.cache(name = "pub_cache", path = ".pub_cache"),
+            swarming.cache(name = "android_sdk", path = "android29"),
+        ],
+        os = "Windows-Server",
+    )
+    common.windows_try_builder(
+        name = "Windows web_tool_tests|web_tool_tests",
+        recipe = "flutter/flutter",
+        repo = repos.FLUTTER,
+        add_cq = True,
+        list_view_name = list_view_name,
+        properties = {
+            "shard": "web_tool_tests",
+            "subshards": ["web"],
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
         },
         caches = [

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -165,14 +165,14 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         ],
     )
     common.linux_prod_builder(
-        name = "Linux%s web_tool_tests|web_tool_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
+        name = "Linux%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
         console_view_name = console_view_name,
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         properties = {
             "shard": "web_tool_tests",
-            "subshards": ["web"],
+            "subshard": "web",
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
         },
         caches = [
@@ -397,14 +397,14 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = "Windows-Server",
     )
     common.windows_prod_builder(
-        name = "Windows%s web_tool_tests|web_tool_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
+        name = "Windows%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
         console_view_name = console_view_name,
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         properties = {
             "shard": "web_tool_tests",
-            "subshards": ["web"],
+            "subshard": "web",
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
         },
         caches = [
@@ -497,14 +497,14 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         ],
     )
     common.mac_prod_builder(
-        name = "Mac%s web_tool_tests|web_tool_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
+        name = "Mac%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
         console_view_name = console_view_name,
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         properties = {
             "shard": "web_tool_tests",
-            "subshards": ["web"],
+            "subshard": "web",
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "goldctl"}],
             "$depot_tools/osx_sdk": {
                 "sdk_version": "11E708",
@@ -617,14 +617,14 @@ def framework_try_config():
         ],
     )
     common.linux_try_builder(
-        name = "Linux web_tool_tests|web_tool_tests",
-        recipe = "flutter/flutter",
+        name = "Linux web_tool_tests|web_tt",
+        recipe = "flutter/flutter_drone",
         repo = repos.FLUTTER,
         add_cq = True,
         list_view_name = list_view_name,
         properties = {
             "shard": "web_tool_tests",
-            "subshards": ["web"],
+            "subshard": "web",
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
         },
         caches = [
@@ -848,14 +848,14 @@ def framework_try_config():
         ],
     )
     common.mac_try_builder(
-        name = "Mac web_tool_tests|web_tool_tests",
-        recipe = "flutter/flutter",
+        name = "Mac web_tool_tests|web_tt",
+        recipe = "flutter/flutter_drone",
         repo = repos.FLUTTER,
         add_cq = True,
         list_view_name = list_view_name,
         properties = {
             "shard": "web_tool_tests",
-            "subshards": ["web"],
+            "subshard": "web",
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "goldctl"}],
             "$depot_tools/osx_sdk": {
                 "sdk_version": "11E708",
@@ -958,14 +958,14 @@ def framework_try_config():
         os = "Windows-Server",
     )
     common.windows_try_builder(
-        name = "Windows web_tool_tests|web_tool_tests",
-        recipe = "flutter/flutter",
+        name = "Windows web_tool_tests|web_tt",
+        recipe = "flutter/flutter_drone",
         repo = repos.FLUTTER,
         add_cq = True,
         list_view_name = list_view_name,
         properties = {
             "shard": "web_tool_tests",
-            "subshards": ["web"],
+            "subshard": "web",
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
         },
         caches = [

--- a/config/generated/flutter/luci/commit-queue.cfg
+++ b/config/generated/flutter/luci/commit-queue.cfg
@@ -103,6 +103,9 @@ config_groups {
         name: "flutter/try/Linux tool_tests"
       }
       builders {
+        name: "flutter/try/Linux web_tool_tests"
+      }
+      builders {
         name: "flutter/try/Mac build_aar_module_test"
       }
       builders {
@@ -112,6 +115,9 @@ config_groups {
         name: "flutter/try/Mac tool_tests"
       }
       builders {
+        name: "flutter/try/Mac web_tool_tests"
+      }
+      builders {
         name: "flutter/try/Windows build_aar_module_test"
       }
       builders {
@@ -119,6 +125,9 @@ config_groups {
       }
       builders {
         name: "flutter/try/Windows tool_tests"
+      }
+      builders {
+        name: "flutter/try/Windows web_tool_tests"
       }
       retry_config {
         single_quota: 1

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -1909,11 +1909,10 @@ buckets {
       name: "Linux beta web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
-      dimensions: "cpu:x64"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter_1_23_0"
+        name: "flutter/flutter_drone_1_23_0"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -1927,7 +1926,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -3477,11 +3476,10 @@ buckets {
       name: "Linux dev web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
-      dimensions: "cpu:x64"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -3495,7 +3493,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -5439,11 +5437,10 @@ buckets {
       name: "Linux stable web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
-      dimensions: "cpu:x64"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter_1_22_0"
+        name: "flutter/flutter_drone_1_22_0"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -5457,7 +5454,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -5755,11 +5752,10 @@ buckets {
       name: "Linux web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
-      dimensions: "cpu:x64"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -5773,7 +5769,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -7418,11 +7414,10 @@ buckets {
     builders {
       name: "Mac beta web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter_1_23_0"
+        name: "flutter/flutter_drone_1_23_0"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
@@ -7436,7 +7431,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -8996,16 +8991,12 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-<<<<<<< HEAD
-      name: "Mac external_ui_integration_test_ios"
-=======
       name: "Mac dev web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
@@ -9019,7 +9010,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -9044,8 +9035,7 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac framework_tests"
->>>>>>> 917fa08 (Add web_tool_tests builders)
+      name: "Mac external_ui_integration_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:14.1"
       dimensions: "os:Mac-10.15.7"
@@ -11933,7 +11923,50 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-<<<<<<< HEAD
+      name: "Mac stable web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshard:\"web\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac tiles_scroll_perf_ios__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:14.1"
@@ -11971,60 +12004,8 @@ buckets {
     }
     builders {
       name: "Mac tool_tests"
-=======
-      name: "Mac stable web_tool_tests"
->>>>>>> 917fa08 (Add web_tool_tests builders)
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_22_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android29"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub_cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-<<<<<<< HEAD
-      dimensions: "os:Windows-10"
-=======
-      dimensions: "cpu:x64"
-      dimensions: "os:Mac-10.15"
->>>>>>> 917fa08 (Add web_tool_tests builders)
       dimensions: "pool:luci.flutter.prod"
       recipe {
         name: "flutter/flutter"
@@ -12068,11 +12049,10 @@ buckets {
     builders {
       name: "Mac web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
@@ -12086,7 +12066,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -12113,7 +12093,6 @@ buckets {
     builders {
       name: "Windows Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -13033,11 +13012,10 @@ buckets {
     builders {
       name: "Windows beta web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter_1_23_0"
+        name: "flutter/flutter_drone_1_23_0"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -13050,7 +13028,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -13843,11 +13821,10 @@ buckets {
     builders {
       name: "Windows dev web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -13860,7 +13837,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -14881,11 +14858,10 @@ buckets {
     builders {
       name: "Windows stable web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter_1_22_0"
+        name: "flutter/flutter_drone_1_22_0"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -14898,7 +14874,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -14960,11 +14936,10 @@ buckets {
     builders {
       name: "Windows web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.prod"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -14977,7 +14952,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -16780,11 +16755,10 @@ buckets {
       name: "Linux web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
-      dimensions: "cpu:x64"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.try"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -16798,7 +16772,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
@@ -17862,11 +17836,10 @@ buckets {
     builders {
       name: "Mac web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.try"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
@@ -17880,7 +17853,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
@@ -18596,11 +18569,10 @@ buckets {
     builders {
       name: "Windows web_tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cpu:x64"
       dimensions: "os:Windows-Server"
       dimensions: "pool:luci.flutter.try"
       recipe {
-        name: "flutter/flutter"
+        name: "flutter/flutter_drone"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
@@ -18613,7 +18585,7 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tool_tests\""
-        properties_j: "subshards:[\"web\"]"
+        properties_j: "subshard:\"web\""
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -1906,6 +1906,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux beta web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_23_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux build_aar_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -3412,6 +3454,48 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tests\""
         properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux dev web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -5352,6 +5436,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux stable web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "cores:8"
@@ -5606,6 +5732,48 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"web_tests\""
         properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -7248,6 +7416,51 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac beta web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_23_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac build_aar_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Mac-10.15"
@@ -8783,7 +8996,56 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+<<<<<<< HEAD
       name: "Mac external_ui_integration_test_ios"
+=======
+      name: "Mac dev web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac framework_tests"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:14.1"
       dimensions: "os:Mac-10.15.7"
@@ -11671,6 +11933,7 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+<<<<<<< HEAD
       name: "Mac tiles_scroll_perf_ios__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:14.1"
@@ -11708,8 +11971,60 @@ buckets {
     }
     builders {
       name: "Mac tool_tests"
+=======
+      name: "Mac stable web_tool_tests"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+<<<<<<< HEAD
+      dimensions: "os:Windows-10"
+=======
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
       dimensions: "pool:luci.flutter.prod"
       recipe {
         name: "flutter/flutter"
@@ -11751,8 +12066,54 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -12670,6 +13031,46 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows beta web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_23_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows build_aar_module_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -13420,6 +13821,46 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\",\"integration\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -14438,6 +14879,46 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows stable web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -14457,6 +14938,46 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\",\"integration\"]"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
@@ -16256,6 +16777,48 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:8"
+      dimensions: "cpu:x64"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Mac-10.15"
@@ -17297,6 +17860,51 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$depot_tools/osx_sdk:{\"sdk_version\":\"11E708\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-10"
@@ -17966,6 +18574,46 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\",\"integration\"]"
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android29"
+      }
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows web_tool_tests"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cpu:x64"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "flutter/flutter"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"web_tool_tests\""
+        properties_j: "subshards:[\"web\"]"
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1536,7 +1536,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_tool_tests"
     category: "Linux"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_integration_tests"
@@ -1606,7 +1606,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Windows stable web_tool_tests"
     category: "Windows"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows stable customer_testing"
@@ -1631,7 +1631,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable web_tool_tests"
     category: "Mac"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable customer_testing"
@@ -1674,7 +1674,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_tool_tests"
     category: "Linux"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_integration_tests"
@@ -1744,7 +1744,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Windows beta web_tool_tests"
     category: "Windows"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows beta customer_testing"
@@ -1769,7 +1769,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta web_tool_tests"
     category: "Mac"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta customer_testing"
@@ -1812,7 +1812,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_tool_tests"
     category: "Linux"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_integration_tests"
@@ -1882,7 +1882,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Windows dev web_tool_tests"
     category: "Windows"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows dev customer_testing"
@@ -1907,7 +1907,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev web_tool_tests"
     category: "Mac"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev customer_testing"
@@ -1945,7 +1945,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Linux web_tool_tests"
     category: "Linux"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux web_integration_tests"
@@ -2015,7 +2015,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Windows web_tool_tests"
     category: "Windows"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows customer_testing"
@@ -2040,7 +2040,7 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.prod/Mac web_tool_tests"
     category: "Mac"
-    short_name: "web_tool_tests"
+    short_name: "web_tt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac customer_testing"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1534,6 +1534,11 @@ consoles {
     short_name: "tool_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Linux stable web_tool_tests"
+    category: "Linux"
+    short_name: "web_tool_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_integration_tests"
     category: "Linux"
     short_name: "web_int"
@@ -1599,6 +1604,11 @@ consoles {
     short_name: "tool_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable web_tool_tests"
+    category: "Windows"
+    short_name: "web_tool_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows stable customer_testing"
     category: "Windows"
     short_name: "cst_test"
@@ -1617,6 +1627,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable web_tool_tests"
+    category: "Mac"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable customer_testing"
@@ -1655,6 +1670,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta tool_tests"
     category: "Linux"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux beta web_tool_tests"
+    category: "Linux"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_integration_tests"
@@ -1722,6 +1742,11 @@ consoles {
     short_name: "tool_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta web_tool_tests"
+    category: "Windows"
+    short_name: "web_tool_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows beta customer_testing"
     category: "Windows"
     short_name: "cst_test"
@@ -1740,6 +1765,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta web_tool_tests"
+    category: "Mac"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta customer_testing"
@@ -1778,6 +1808,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux dev tool_tests"
     category: "Linux"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux dev web_tool_tests"
+    category: "Linux"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_integration_tests"
@@ -1845,6 +1880,11 @@ consoles {
     short_name: "tool_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev web_tool_tests"
+    category: "Windows"
+    short_name: "web_tool_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows dev customer_testing"
     category: "Windows"
     short_name: "cst_test"
@@ -1863,6 +1903,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev web_tool_tests"
+    category: "Mac"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev customer_testing"
@@ -1896,6 +1941,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux tool_tests"
     category: "Linux"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Linux web_tool_tests"
+    category: "Linux"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux web_integration_tests"
@@ -1963,6 +2013,11 @@ consoles {
     short_name: "tool_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows web_tool_tests"
+    category: "Windows"
+    short_name: "web_tool_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows customer_testing"
     category: "Windows"
     short_name: "cst_test"
@@ -1981,6 +2036,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac web_tool_tests"
+    category: "Mac"
+    short_name: "web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac customer_testing"
@@ -2005,6 +2065,9 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Linux web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_tests"
@@ -2052,6 +2115,9 @@ consoles {
     name: "buildbucket/luci.flutter.try/Mac tool_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.try/Mac web_tool_tests"
+  }
+  builders {
     name: "buildbucket/luci.flutter.try/Mac SDK Drone"
   }
   builders {
@@ -2068,6 +2134,9 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Windows web_tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows SDK Drone"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -506,6 +506,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux beta web_tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux build_aar_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -903,6 +914,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev web_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux dev web_tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1430,6 +1452,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Linux stable web_tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Linux tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1497,6 +1530,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux web_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Linux web_tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1881,6 +1925,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac beta web_tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac build_aar_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2255,6 +2310,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
+<<<<<<< HEAD
     name: "Mac external_ui_integration_test_ios"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2322,6 +2378,9 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac flutter_view_ios__start_up"
+=======
+    name: "Mac dev web_tool_tests"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -3014,7 +3073,11 @@ notifiers {
   }
   builders {
     bucket: "prod"
+<<<<<<< HEAD
     name: "Mac tiles_scroll_perf_ios__timeline_summary"
+=======
+    name: "Mac stable web_tool_tests"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -3026,6 +3089,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac web_tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -3278,6 +3352,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows beta web_tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows build_aar_module_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -3477,6 +3562,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows dev tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev web_tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -3762,7 +3858,29 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows stable web_tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows web_tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -2310,7 +2310,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
-<<<<<<< HEAD
+    name: "Mac dev web_tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac external_ui_integration_test_ios"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2378,9 +2388,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac flutter_view_ios__start_up"
-=======
-    name: "Mac dev web_tool_tests"
->>>>>>> 917fa08 (Add web_tool_tests builders)
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -3073,11 +3080,18 @@ notifiers {
   }
   builders {
     bucket: "prod"
-<<<<<<< HEAD
-    name: "Mac tiles_scroll_perf_ios__timeline_summary"
-=======
     name: "Mac stable web_tool_tests"
->>>>>>> 917fa08 (Add web_tool_tests builders)
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac tiles_scroll_perf_ios__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -2890,26 +2890,30 @@ job {
   }
 }
 job {
-<<<<<<< HEAD
-  id: "Mac external_ui_integration_test_ios"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
-    max_batch_size: 20
-=======
   id: "Mac dev web_tool_tests"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
     max_batch_size: 1
->>>>>>> 917fa08 (Add web_tool_tests builders)
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
-<<<<<<< HEAD
+    builder: "Mac dev web_tool_tests"
+  }
+}
+job {
+  id: "Mac external_ui_integration_test_ios"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 2
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
     builder: "Mac external_ui_integration_test_ios"
   }
 }
@@ -2995,9 +2999,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac flutter_view_ios__start_up"
-=======
-    builder: "Mac dev web_tool_tests"
->>>>>>> 917fa08 (Add web_tool_tests builders)
   }
 }
 job {
@@ -3862,30 +3863,31 @@ job {
   }
 }
 job {
-<<<<<<< HEAD
-  id: "Mac tiles_scroll_perf_ios__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
-    max_batch_size: 20
-=======
   id: "Mac stable web_tool_tests"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 3
     max_batch_size: 1
->>>>>>> 917fa08 (Add web_tool_tests builders)
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
-<<<<<<< HEAD
-    builder: "Mac tiles_scroll_perf_ios__timeline_summary"
-=======
     builder: "Mac stable web_tool_tests"
->>>>>>> 917fa08 (Add web_tool_tests builders)
+  }
+}
+job {
+  id: "Mac tiles_scroll_perf_ios__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 2
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac tiles_scroll_perf_ios__timeline_summary"
   }
 }
 job {

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -625,6 +625,20 @@ job {
   }
 }
 job {
+  id: "Linux beta web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux beta web_tool_tests"
+  }
+}
+job {
   id: "Linux build_aar_module_test"
   acl_sets: "prod"
   triggering_policy {
@@ -1133,6 +1147,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev web_tests"
+  }
+}
+job {
+  id: "Linux dev web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux dev web_tool_tests"
   }
 }
 job {
@@ -1787,6 +1815,20 @@ job {
   }
 }
 job {
+  id: "Linux stable web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux stable web_tool_tests"
+  }
+}
+job {
   id: "Linux tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -1882,6 +1924,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux web_tests"
+  }
+}
+job {
+  id: "Linux web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Linux web_tool_tests"
   }
 }
 job {
@@ -2348,6 +2404,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac beta verify_binaries_codesigned"
+  }
+}
+job {
+  id: "Mac beta web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta web_tool_tests"
   }
 }
 job {
@@ -2820,16 +2890,26 @@ job {
   }
 }
 job {
+<<<<<<< HEAD
   id: "Mac external_ui_integration_test_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 2
     max_batch_size: 20
+=======
+  id: "Mac dev web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+>>>>>>> 917fa08 (Add web_tool_tests builders)
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
+<<<<<<< HEAD
     builder: "Mac external_ui_integration_test_ios"
   }
 }
@@ -2915,6 +2995,9 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac flutter_view_ios__start_up"
+=======
+    builder: "Mac dev web_tool_tests"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
   }
 }
 job {
@@ -3779,17 +3862,30 @@ job {
   }
 }
 job {
+<<<<<<< HEAD
   id: "Mac tiles_scroll_perf_ios__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
     max_concurrent_invocations: 2
     max_batch_size: 20
+=======
+  id: "Mac stable web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+>>>>>>> 917fa08 (Add web_tool_tests builders)
   }
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
+<<<<<<< HEAD
     builder: "Mac tiles_scroll_perf_ios__timeline_summary"
+=======
+    builder: "Mac stable web_tool_tests"
+>>>>>>> 917fa08 (Add web_tool_tests builders)
   }
 }
 job {
@@ -3804,6 +3900,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac tool_tests"
+  }
+}
+job {
+  id: "Mac web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac web_tool_tests"
   }
 }
 job {
@@ -4109,6 +4219,20 @@ job {
   }
 }
 job {
+  id: "Windows beta web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta web_tool_tests"
+  }
+}
+job {
   id: "Windows build_aar_module_test"
   acl_sets: "prod"
   triggering_policy {
@@ -4369,6 +4493,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows dev tool_tests"
+  }
+}
+job {
+  id: "Windows dev web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev web_tool_tests"
   }
 }
 job {
@@ -4719,6 +4857,20 @@ job {
   }
 }
 job {
+  id: "Windows stable web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable web_tool_tests"
+  }
+}
+job {
   id: "Windows tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -4730,6 +4882,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows tool_tests"
+  }
+}
+job {
+  id: "Windows web_tool_tests"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows web_tool_tests"
   }
 }
 job {
@@ -4933,15 +5099,18 @@ trigger {
   triggers: "Linux beta web_long_running_tests"
   triggers: "Linux beta web_smoke_test"
   triggers: "Linux beta web_tests"
+  triggers: "Linux beta web_tool_tests"
   triggers: "Mac beta build_gallery"
   triggers: "Mac beta build_tests"
   triggers: "Mac beta customer_testing"
   triggers: "Mac beta framework_tests"
   triggers: "Mac beta tool_tests"
+  triggers: "Mac beta web_tool_tests"
   triggers: "Windows beta build_tests"
   triggers: "Windows beta customer_testing"
   triggers: "Windows beta framework_tests"
   triggers: "Windows beta tool_tests"
+  triggers: "Windows beta web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/flutter-1\\.23-candidate\\.18"
@@ -5050,15 +5219,18 @@ trigger {
   triggers: "Linux dev web_long_running_tests"
   triggers: "Linux dev web_smoke_test"
   triggers: "Linux dev web_tests"
+  triggers: "Linux dev web_tool_tests"
   triggers: "Mac dev build_gallery"
   triggers: "Mac dev build_tests"
   triggers: "Mac dev customer_testing"
   triggers: "Mac dev framework_tests"
   triggers: "Mac dev tool_tests"
+  triggers: "Mac dev web_tool_tests"
   triggers: "Windows dev build_tests"
   triggers: "Windows dev customer_testing"
   triggers: "Windows dev framework_tests"
   triggers: "Windows dev tool_tests"
+  triggers: "Windows dev web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/flutter-1\\.24-candidate\\..+"
@@ -5276,15 +5448,18 @@ trigger {
   triggers: "Linux web_long_running_tests"
   triggers: "Linux web_smoke_test"
   triggers: "Linux web_tests"
+  triggers: "Linux web_tool_tests"
   triggers: "Mac build_gallery"
   triggers: "Mac build_tests"
   triggers: "Mac customer_testing"
   triggers: "Mac framework_tests"
   triggers: "Mac tool_tests"
+  triggers: "Mac web_tool_tests"
   triggers: "Windows build_tests"
   triggers: "Windows customer_testing"
   triggers: "Windows framework_tests"
   triggers: "Windows tool_tests"
+  triggers: "Windows web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/master"
@@ -5391,15 +5566,18 @@ trigger {
   triggers: "Linux stable web_long_running_tests"
   triggers: "Linux stable web_smoke_test"
   triggers: "Linux stable web_tests"
+  triggers: "Linux stable web_tool_tests"
   triggers: "Mac stable build_gallery"
   triggers: "Mac stable build_tests"
   triggers: "Mac stable customer_testing"
   triggers: "Mac stable framework_tests"
   triggers: "Mac stable tool_tests"
+  triggers: "Mac stable web_tool_tests"
   triggers: "Windows stable build_tests"
   triggers: "Windows stable customer_testing"
   triggers: "Windows stable framework_tests"
   triggers: "Windows stable tool_tests"
+  triggers: "Windows stable web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
     refs: "regexp:refs/heads/flutter-1\\.22-candidate\\.12"


### PR DESCRIPTION
Made `web_tool_tests` shards and its `web` subshard to run on a separate builder.

Web tool tests run frontend server in web mode, invoking ddc as the backend compiler, and uses some SDK API that are not used on other platforms, such as ExpressionCompiler. This change will allow:

- Fast checks of dart SDK CLs against breaking flutter.
- Marking some shards as flaky separately from the rest of tool tests.

See matching changes in flutter:

https://github.com/flutter/flutter/pull/70226