### PR TITLE
Increase staging builders expiration_timeout to be 12 hours

### DIFF
--- a/config/devicelab_staging_config.star
+++ b/config/devicelab_staging_config.star
@@ -128,6 +128,7 @@ def devicelab_staging_prod_config():
             os = "Mac-10.15.7",
             dimensions = {"device_os": "14.1"},
             execution_timeout = timeout.SHORT,
+            expiration_timeout = timeout.LONG_EXPIRATION,
         )
 
     # Linux prod builders.
@@ -200,6 +201,7 @@ def devicelab_staging_prod_config():
             pool = "luci.flutter.staging",
             os = "Android",
             dimensions = {"device_os": "N"},
+            expiration_timeout = timeout.LONG_EXPIRATION,
         )
 
 devicelab_staging_config = struct(setup = _setup)

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -509,6 +509,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -541,6 +542,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -573,6 +575,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -605,6 +608,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -637,6 +641,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -669,6 +674,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -701,6 +707,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -733,6 +740,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2295,6 +2303,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2327,6 +2336,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2359,6 +2369,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2391,6 +2402,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2423,6 +2435,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2455,6 +2468,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2487,6 +2501,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -2519,6 +2534,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -3997,6 +4013,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4146,6 +4163,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4178,6 +4196,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4210,6 +4229,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4242,6 +4262,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4274,6 +4295,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4306,6 +4328,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4338,6 +4361,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4370,6 +4394,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4402,6 +4427,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4434,6 +4460,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4466,6 +4493,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4498,6 +4526,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4530,6 +4559,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4562,6 +4592,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4594,6 +4625,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4853,6 +4885,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4885,6 +4918,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4917,6 +4951,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4949,6 +4984,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -4981,6 +5017,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5130,6 +5167,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5162,6 +5200,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5194,6 +5233,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5226,6 +5266,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5258,6 +5299,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -5329,6 +5371,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -6734,6 +6777,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -6957,6 +7001,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 3600
+      expiration_secs: 43200
       caches {
         name: "flutter_openjdk_install"
         path: "java"
@@ -7473,6 +7518,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -7509,6 +7555,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -8941,6 +8988,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -8977,6 +9025,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -9013,6 +9062,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -9049,6 +9099,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10350,6 +10401,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10386,6 +10438,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10422,6 +10475,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10458,6 +10512,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10494,6 +10549,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10530,6 +10586,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10566,6 +10623,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10814,6 +10872,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -10850,6 +10909,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11042,6 +11102,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11078,6 +11139,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11114,6 +11176,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11150,6 +11213,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11186,6 +11250,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11222,6 +11287,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11258,6 +11324,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11294,6 +11361,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11330,6 +11398,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11366,6 +11435,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11402,6 +11472,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11610,6 +11681,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11646,6 +11718,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11682,6 +11755,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11718,6 +11792,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11754,6 +11829,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11790,6 +11866,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11912,6 +11989,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11948,6 +12026,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -11984,6 +12063,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -12020,6 +12100,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
@@ -13282,6 +13363,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
+      expiration_secs: 43200
       caches {
         name: "osx_sdk"
         path: "osx_sdk"

--- a/config/lib/timeout.star
+++ b/config/lib/timeout.star
@@ -9,5 +9,7 @@ timeout = struct(
     MEDIUM = 60 * time.minute,
     LONG = 90 * time.minute,
     XL = 180 * time.minute,
+    # EXPIRATION is used to set builder expiration_timeout, which controls
+    # how long to wait for a build to be picked up before canceling.
     LONG_EXPIRATION = 12 * 60 * time.minute,
 )

--- a/config/lib/timeout.star
+++ b/config/lib/timeout.star
@@ -9,4 +9,5 @@ timeout = struct(
     MEDIUM = 60 * time.minute,
     LONG = 90 * time.minute,
     XL = 180 * time.minute,
+    LONG_EXPIRATION = 12 * 60 * time.minute,
 )


### PR DESCRIPTION
We are running all mac/linux devicelab tests in staging pool, but with 2 bots for each platform. The default 6 hours make it difficult to see whether all tests pass.

This PR increase the expiration_timeout to be 12 hours to have a better visibility.