### PR TITLE
adding web drones which will be called from web engine code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "files.associations": {
-    "*.star": "python"
+    "*.star": "starlark"
   }
 }

--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -61,6 +61,7 @@ def engine_recipes(version):
         "femu_test",
         "engine/engine_metrics",
         "engine/scenarios",
+        "engine/web_engine_drone",
         "engine/web_engine_framework",
     ]
     for name in recipe_list:
@@ -234,6 +235,15 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
         **platform_args["windows"]
+    )
+    common.linux_prod_builder(
+        name = builder_name("Linux%s Web Drone|webdrn", branch),
+        recipe = full_recipe_name("engine/web_engine_drone", version),
+        properties = engine_properties(gcs_goldens_bucket = "flutter_logs"),
+        console_view_name = None,
+        no_notify = True,
+        priority = 28 if branch == "master" else 25,
+        **platform_args["linux"]
     )
     common.linux_prod_builder(
         name = builder_name("Linux%s Web Framework tests|web_tests", branch),
@@ -491,6 +501,17 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
             framework = True,
             shard = "web_tests",
             subshards = ["0", "1", "2", "3", "4", "5", "6", "7_last"],
+        ),
+        **platform_args["linux"]
+    )
+    common.linux_try_builder(
+        name = "Linux Web Drone|webdrn",
+        recipe = "engine/web_engine_drone",
+        repo = repos.ENGINE,
+        list_view_name = list_view_name,
+        properties = engine_properties(
+            gcs_goldens_bucket = "flutter_logs",
+            no_lto = True,
         ),
         **platform_args["linux"]
     )

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -373,6 +373,44 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux Web Drone"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"flutter_logs\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 28
+      execution_timeout_secs: 3600
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -1043,6 +1081,44 @@ buckets {
       caches {
         name: "pub_cache"
         path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux beta Web Drone"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_drone_1_24_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"flutter_logs\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 25
+      execution_timeout_secs: 3600
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -2835,6 +2911,44 @@ buckets {
       caches {
         name: "pub_cache"
         path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux dev Web Drone"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"flutter_logs\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 25
+      execution_timeout_secs: 3600
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -5638,6 +5752,44 @@ buckets {
       caches {
         name: "pub_cache"
         path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux stable Web Drone"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "engine/web_engine_drone_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"flutter_logs\""
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 25
+      execution_timeout_secs: 3600
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -16975,6 +17127,44 @@ buckets {
       caches {
         name: "pub_cache"
         path: ".pub_cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Linux Web Drone"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "engine/web_engine_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "build_android_aot:false"
+        properties_j: "build_android_debug:false"
+        properties_j: "build_android_jit_release:false"
+        properties_j: "build_android_vulkan:false"
+        properties_j: "build_fuchsia:false"
+        properties_j: "build_host:false"
+        properties_j: "build_ios:false"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gcs_goldens_bucket:\"flutter_logs\""
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "no_lto:true"
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
+      caches {
+        name: "flutter_openjdk_install"
+        path: "java"
       }
       build_numbers: YES
       service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1685,6 +1685,9 @@ consoles {
     name: "buildbucket/luci.flutter.try/Linux Web Framework tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.try/Linux Web Drone"
+  }
+  builders {
     name: "buildbucket/luci.flutter.try/Linux Host Engine"
   }
   builders {


### PR DESCRIPTION
This is for adding web engine drone builders.

These will be used from the web engine recipe, for sharding (which will eliminate the flakiness happening now on linux web engine) The related design doc: go/web-engine-recipe-drones

related: https://github.com/flutter/flutter/issues/71576