### PR TITLE
Change `max_concurrent_invocations` to 1 for luci devicelab builders

### DIFF
--- a/config/devicelab_config.star
+++ b/config/devicelab_config.star
@@ -78,7 +78,7 @@ def devicelab_prod_config(branch, version, ref):
     if branch == "master":
         triggering_policy = scheduler.greedy_batching(
             max_batch_size = 3,
-            max_concurrent_invocations = 3,
+            max_concurrent_invocations = 1,
         )
     else:
         triggering_policy = scheduler.greedy_batching(

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -160,7 +160,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -174,7 +174,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -188,7 +188,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -202,7 +202,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -216,7 +216,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -230,7 +230,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -244,7 +244,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -258,7 +258,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1441,7 +1441,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1483,7 +1483,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1497,7 +1497,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1511,7 +1511,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1525,7 +1525,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1539,7 +1539,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1553,7 +1553,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1567,7 +1567,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1581,7 +1581,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -1609,7 +1609,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2792,7 +2792,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2848,7 +2848,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2862,7 +2862,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2876,7 +2876,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2890,7 +2890,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2904,7 +2904,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2918,7 +2918,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2932,7 +2932,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2946,7 +2946,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2960,7 +2960,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2974,7 +2974,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -2988,7 +2988,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3002,7 +3002,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3016,7 +3016,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3044,7 +3044,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3058,7 +3058,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3100,7 +3100,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3114,7 +3114,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3128,7 +3128,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3142,7 +3142,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3156,7 +3156,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3170,7 +3170,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3184,7 +3184,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3198,7 +3198,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3212,7 +3212,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3226,7 +3226,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3240,7 +3240,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3254,7 +3254,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3268,7 +3268,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3282,7 +3282,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3296,7 +3296,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3310,7 +3310,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3324,7 +3324,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3338,7 +3338,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -3352,7 +3352,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -4521,7 +4521,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -4535,7 +4535,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -4563,7 +4563,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -4577,7 +4577,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -4633,7 +4633,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5211,7 +5211,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5239,7 +5239,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5652,7 +5652,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5666,7 +5666,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5680,7 +5680,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5694,7 +5694,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5750,7 +5750,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5764,7 +5764,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5778,7 +5778,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5792,7 +5792,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5806,7 +5806,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -5820,7 +5820,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7053,7 +7053,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7344,7 +7344,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7358,7 +7358,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7372,7 +7372,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7386,7 +7386,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7400,7 +7400,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7414,7 +7414,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7428,7 +7428,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {
@@ -7442,7 +7442,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
+    max_concurrent_invocations: 1
     max_batch_size: 3
   }
   buildbucket {


### PR DESCRIPTION
There are five bots running 45 LUCI devicelab builders.

Current setting `max_concurrent_invocations=3` makes the queue time super high:
<img width="687" alt="Screen Shot 2020-12-16 at 12 37 24 PM" src="https://user-images.githubusercontent.com/54558023/102403675-79bf6800-3f9b-11eb-8211-29c6897a941f.png">

Like in the above picture, each builder has three queued builds. This will make the tot builds queuing time even higher if we have continuous more new commits joining. (after finish running a build, it may choose to run an older queued build).

Updating `max_concurrent_invocations` to 1 should have the scheduler always choose newer build to run.

From [quote](https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/master/lucicfg/doc/README.md#scheduler.policy-args)
> max_concurrent_invocations: limit on a number of builds running at the same time. If the number of currently running builds launched through LUCI Scheduler is more than or equal to this setting, LUCI Scheduler will keep queuing up triggering requests, waiting for some running build to finish before starting a new one. Default is 1.
