### PR TITLE
Add try builder config for cocoon device doctor

### DIFF
--- a/config/cocoon_config.star
+++ b/config/cocoon_config.star
@@ -18,25 +18,18 @@ def _setup():
             "caches": [swarming.cache(name = "dart_pub_cache", path = ".pub-cache")],
         },
     }
-    cocoon_define_recipes()
-    device_doctor_recipes()
+    cocoon_recipes()
     cocoon_try_config(platform_args)
 
-def cocoon_define_recipes():
-    # Defines recipes
-    luci.recipe(
-        name = "cocoon",
-        cipd_package = "flutter/recipe_bundles/flutter.googlesource.com/recipes",
-        cipd_version = "refs/heads/master",
-    )
+recipe_names = ["cocoon/cocoon", "cocoon/device_doctor"]
 
-def device_doctor_recipes():
-    # Defines recipes
-    luci.recipe(
-        name = "cocoon/device_doctor",
-        cipd_package = "flutter/recipe_bundles/flutter.googlesource.com/recipes",
-        cipd_version = "refs/heads/master",
-    )
+def cocoon_recipes():
+    for recipe in recipe_names:
+        luci.recipe(
+            name = recipe,
+            cipd_package = "flutter/recipe_bundles/flutter.googlesource.com/recipes",
+            cipd_version = "refs/heads/master",
+        )
 
 def cocoon_try_config(platform_args):
     """Creates try cocoon configurations.
@@ -55,7 +48,7 @@ def cocoon_try_config(platform_args):
     # Defines cocoon linux try builders
     common.linux_try_builder(
         name = "Cocoon|cocoon",
-        recipe = "cocoon",
+        recipe = "cocoon/cocoon",
         list_view_name = list_view_name,
         repo = repos.COCOON,
         add_cq = True,

--- a/config/cocoon_config.star
+++ b/config/cocoon_config.star
@@ -19,12 +19,21 @@ def _setup():
         },
     }
     cocoon_define_recipes()
+    device_doctor_recipes()
     cocoon_try_config(platform_args)
 
 def cocoon_define_recipes():
     # Defines recipes
     luci.recipe(
         name = "cocoon",
+        cipd_package = "flutter/recipe_bundles/flutter.googlesource.com/recipes",
+        cipd_version = "refs/heads/master",
+    )
+
+def device_doctor_recipes():
+    # Defines recipes
+    luci.recipe(
+        name = "cocoon/device_doctor",
         cipd_package = "flutter/recipe_bundles/flutter.googlesource.com/recipes",
         cipd_version = "refs/heads/master",
     )
@@ -37,7 +46,7 @@ def cocoon_try_config(platform_args):
         title = "Cocoon try builders",
     )
 
-    # Defines cocoon try builders
+    # Defines cocoon linux try builders
     common.linux_try_builder(
         name = "Cocoon|cocoon",
         recipe = "cocoon",
@@ -45,6 +54,31 @@ def cocoon_try_config(platform_args):
         repo = repos.COCOON,
         add_cq = True,
         **platform_args["linux"]
+    )
+    common.linux_try_builder(
+        name = "Linux device_doctor|device_doctor",
+        recipe = "cocoon/device_doctor",
+        list_view_name = list_view_name,
+        repo = repos.COCOON,
+        add_cq = True,
+    )
+
+    # Defines cocoon mac try builders
+    common.mac_try_builder(
+        name = "Mac device_doctor|device_doctor",
+        recipe = "cocoon/device_doctor",
+        list_view_name = list_view_name,
+        repo = repos.COCOON,
+        add_cq = True,
+    )
+
+    # Defines cocoon windows try builders
+    common.windows_try_builder(
+        name = "Windows device_doctor|device_doctor",
+        recipe = "cocoon/device_doctor",
+        list_view_name = list_view_name,
+        repo = repos.COCOON,
+        add_cq = True,
     )
 
 cocoon_config = struct(setup = _setup)

--- a/config/cocoon_config.star
+++ b/config/cocoon_config.star
@@ -39,7 +39,13 @@ def device_doctor_recipes():
     )
 
 def cocoon_try_config(platform_args):
-    # Defines a list view for try builders
+    """Creates try cocoon configurations.
+
+    Args:
+      platform_args(dict): Dictionary with the default properties with the platform
+        as key.
+    """
+
     list_view_name = "cocoon-try"
     luci.list_view(
         name = list_view_name,

--- a/config/generated/flutter/luci/commit-queue.cfg
+++ b/config/generated/flutter/luci/commit-queue.cfg
@@ -22,6 +22,15 @@ config_groups {
       builders {
         name: "flutter/try/Cocoon"
       }
+      builders {
+        name: "flutter/try/Linux device_doctor"
+      }
+      builders {
+        name: "flutter/try/Mac device_doctor"
+      }
+      builders {
+        name: "flutter/try/Windows device_doctor"
+      }
       retry_config {
         single_quota: 1
         global_quota: 2

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -19503,7 +19503,7 @@ buckets {
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.try"
       recipe {
-        name: "cocoon"
+        name: "cocoon/cocoon"
         cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
         cipd_version: "refs/heads/master"
         properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -20072,6 +20072,31 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Linux device_doctor"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Linux"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "cocoon/device_doctor"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Linux docs"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -21291,6 +21316,30 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac device_doctor"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "cocoon/device_doctor"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac framework_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Mac-10.15"
@@ -22076,6 +22125,30 @@ buckets {
         name: "pub_cache"
         path: ".pub_cache"
       }
+      build_numbers: YES
+      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows device_doctor"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-10"
+      dimensions: "pool:luci.flutter.try"
+      recipe {
+        name: "cocoon/device_doctor"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "gold_tryjob:true"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "upload_packages:false"
+      }
+      execution_timeout_secs: 3600
       build_numbers: YES
       service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
       task_template_canary_percentage {}

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -10,6 +10,15 @@ consoles {
   builders {
     name: "buildbucket/luci.flutter.try/Cocoon"
   }
+  builders {
+    name: "buildbucket/luci.flutter.try/Linux device_doctor"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Mac device_doctor"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.try/Windows device_doctor"
+  }
   favicon_url: "https://storage.googleapis.com/flutter_infra/favicon.ico"
   builder_view_only: true
 }


### PR DESCRIPTION
Cocoon device doctor recipe to build/upload device_doctor package to cipd is ready. This PR adds pre-submit builder configs.

These builders should be triggered whenever any updates from `cocoon/device_doctor`.