### PR TITLE
Enable devicelab Mac android tests in staging env

### DIFF
--- a/config/devicelab_staging_config.star
+++ b/config/devicelab_staging_config.star
@@ -210,7 +210,7 @@ def devicelab_staging_prod_config():
     ]
 
     for task in mac_android_tasks:
-        common.mac_android_prod_builder(
+        common.mac_prod_builder(
             name = "Mac_android %s|%s" % (task, short_name(task)),
             recipe = drone_recipe_name,
             console_view_name = console_view_name,
@@ -232,6 +232,7 @@ def devicelab_staging_prod_config():
             },
             pool = "luci.flutter.staging",
             os = "Mac",
+            category = "Mac_android",
             dimensions = {"device_os": "N"},
             expiration_timeout = timeout.LONG_EXPIRATION,
             execution_timeout = timeout.SHORT,

--- a/config/devicelab_staging_config.star
+++ b/config/devicelab_staging_config.star
@@ -28,6 +28,20 @@ LINUX_DEFAULT_CACHES = [
     swarming.cache(name = "flutter_sdk", path = "flutter sdk"),
 ]
 
+# Default caches for Mac android builders
+MAC_ANDROID_DEFAULT_CACHES = [
+    # Android SDK
+    swarming.cache(name = "android_sdk", path = "android"),
+    # Chrome
+    swarming.cache(name = "chrome_and_driver", path = "chrome"),
+    # OpenJDK
+    swarming.cache(name = "openjdk", path = "java"),
+    # PubCache
+    swarming.cache(name = "pub_cache", path = ".pub-cache"),
+    # Flutter SDK code
+    swarming.cache(name = "flutter_sdk", path = "flutter sdk"),
+]
+
 # Default caches for Mac builders
 MAC_DEFAULT_CACHES = [
     # Pub cache
@@ -197,7 +211,7 @@ def devicelab_staging_prod_config():
 
     for task in mac_android_tasks:
         common.mac_android_prod_builder(
-            name = "Mac_staging %s|%s" % (task, short_name(task)),
+            name = "Mac_android %s|%s" % (task, short_name(task)),
             recipe = drone_recipe_name,
             console_view_name = console_view_name,
             triggered_by = [trigger_name],
@@ -220,7 +234,8 @@ def devicelab_staging_prod_config():
             os = "Mac",
             dimensions = {"device_os": "N"},
             expiration_timeout = timeout.LONG_EXPIRATION,
-            caches = LINUX_DEFAULT_CACHES,
+            execution_timeout = timeout.SHORT,
+            caches = MAC_ANDROID_DEFAULT_CACHES,
         )
 
     # Linux prod builders.

--- a/config/devicelab_staging_config.star
+++ b/config/devicelab_staging_config.star
@@ -77,12 +77,12 @@ def devicelab_staging_prod_config():
     # Defines triggering policy
     triggering_policy = scheduler.greedy_batching(
         max_batch_size = 20,
-        max_concurrent_invocations = 2,
+        max_concurrent_invocations = 1,
     )
     # Defines framework prod builders
 
     # Mac prod builders.
-    mac_tasks = [
+    mac_ios_tasks = [
         "backdrop_filter_perf_ios__timeline_summary",
         "basic_material_app_ios__compile",
         "channels_integration_test_ios",
@@ -121,7 +121,7 @@ def devicelab_staging_prod_config():
         "smoke_catalina_start_up_ios",
         "tiles_scroll_perf_ios__timeline_summary",
     ]
-    for task in mac_tasks:
+    for task in mac_ios_tasks:
         common.mac_prod_builder(
             name = "Mac_staging %s|%s" % (task, short_name(task)),
             recipe = drone_recipe_name,
@@ -151,6 +151,76 @@ def devicelab_staging_prod_config():
             execution_timeout = timeout.SHORT,
             expiration_timeout = timeout.LONG_EXPIRATION,
             caches = MAC_DEFAULT_CACHES,
+        )
+
+    mac_android_tasks = [
+        "android_plugin_example_app_build_test",
+        "android_semantics_integration_test",
+        "backdrop_filter_perf__timeline_summary",
+        "channels_integration_test",
+        "color_filter_and_fade_perf__timeline_summary",
+        "complex_layout_scroll_perf__memory",
+        "complex_layout_scroll_perf__timeline_summary",
+        "complex_layout__start_up",
+        "cubic_bezier_perf_sksl_warmup__timeline_summary",
+        "cubic_bezier_perf__timeline_summary",
+        "cull_opacity_perf__timeline_summary",
+        "drive_perf_debug_warning",
+        "embedded_android_views_integration_test",
+        "external_ui_integration_test",
+        "fading_child_animation_perf__timeline_summary",
+        "fast_scroll_large_images__memory",
+        "flavors_test",
+        "flutter_view__start_up",
+        "fullscreen_textfield_perf__timeline_summary",
+        "hello_world_android__compile",
+        "hello_world__memory",
+        "home_scroll_perf__timeline_summary",
+        "hot_mode_dev_cycle__benchmark",
+        "hybrid_android_views_integration_test",
+        "imagefiltered_transform_animation_perf__timeline_summary",
+        "integration_ui_driver",
+        "integration_ui_keyboard_resize",
+        "integration_ui_screenshot",
+        "integration_ui_textfield",
+        "microbenchmarks",
+        "new_gallery__transition_perf",
+        "picture_cache_perf__timeline_summary",
+        "platform_channel_sample_test",
+        "platform_interaction_test",
+        "platform_view__start_up",
+        "run_release_test",
+        "service_extensions_test",
+        "textfield_perf__timeline_summary",
+        "tiles_scroll_perf__timeline_summary",
+    ]
+
+    for task in mac_android_tasks:
+        common.mac_android_prod_builder(
+            name = "Mac_staging %s|%s" % (task, short_name(task)),
+            recipe = drone_recipe_name,
+            console_view_name = console_view_name,
+            triggered_by = [trigger_name],
+            triggering_policy = triggering_policy,
+            properties = {
+                "dependencies": [
+                    {
+                        "dependency": "android_sdk",
+                    },
+                    {
+                        "dependency": "chrome_and_driver",
+                    },
+                    {
+                        "dependency": "open_jdk",
+                    },
+                ],
+                "task_name": task,
+            },
+            pool = "luci.flutter.staging",
+            os = "Mac",
+            dimensions = {"device_os": "N"},
+            expiration_timeout = timeout.LONG_EXPIRATION,
+            caches = LINUX_DEFAULT_CACHES,
         )
 
     # Linux prod builders.

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -22634,7 +22634,7 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging android_plugin_example_app_build_test"
+      name: "Mac_android android_plugin_example_app_build_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:N"
       dimensions: "os:Mac"
@@ -22655,7 +22655,7 @@ buckets {
         properties_j: "task_name:\"android_plugin_example_app_build_test\""
         properties_j: "upload_packages:true"
       }
-      execution_timeout_secs: 3600
+      execution_timeout_secs: 1800
       expiration_secs: 43200
       caches {
         name: "android_sdk"
@@ -22682,7 +22682,7 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging android_semantics_integration_test"
+      name: "Mac_android android_semantics_integration_test"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:N"
       dimensions: "os:Mac"
@@ -22703,7 +22703,7 @@ buckets {
         properties_j: "task_name:\"android_semantics_integration_test\""
         properties_j: "upload_packages:true"
       }
-      execution_timeout_secs: 3600
+      execution_timeout_secs: 1800
       expiration_secs: 43200
       caches {
         name: "android_sdk"
@@ -22730,7 +22730,7 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging backdrop_filter_perf__timeline_summary"
+      name: "Mac_android backdrop_filter_perf__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:N"
       dimensions: "os:Mac"
@@ -22751,7 +22751,1735 @@ buckets {
         properties_j: "task_name:\"backdrop_filter_perf__timeline_summary\""
         properties_j: "upload_packages:true"
       }
-      execution_timeout_secs: 3600
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android channels_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"channels_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android color_filter_and_fade_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"color_filter_and_fade_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android complex_layout__start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"complex_layout__start_up\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android complex_layout_scroll_perf__memory"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"complex_layout_scroll_perf__memory\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android complex_layout_scroll_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"complex_layout_scroll_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android cubic_bezier_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"cubic_bezier_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"cubic_bezier_perf_sksl_warmup__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android cull_opacity_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"cull_opacity_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android drive_perf_debug_warning"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"drive_perf_debug_warning\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android embedded_android_views_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"embedded_android_views_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android external_ui_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"external_ui_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android fading_child_animation_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"fading_child_animation_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android fast_scroll_large_images__memory"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"fast_scroll_large_images__memory\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android flavors_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"flavors_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android flutter_view__start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"flutter_view__start_up\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android fullscreen_textfield_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"fullscreen_textfield_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android hello_world__memory"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hello_world__memory\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android hello_world_android__compile"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hello_world_android__compile\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android home_scroll_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"home_scroll_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android hot_mode_dev_cycle__benchmark"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hot_mode_dev_cycle__benchmark\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android hybrid_android_views_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hybrid_android_views_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android imagefiltered_transform_animation_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"imagefiltered_transform_animation_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android integration_ui_driver"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_driver\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android integration_ui_keyboard_resize"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_keyboard_resize\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android integration_ui_screenshot"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_screenshot\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android integration_ui_textfield"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_textfield\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android microbenchmarks"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"microbenchmarks\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android new_gallery__transition_perf"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"new_gallery__transition_perf\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android picture_cache_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"picture_cache_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android platform_channel_sample_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"platform_channel_sample_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android platform_interaction_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"platform_interaction_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android platform_view__start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"platform_view__start_up\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android run_release_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"run_release_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android service_extensions_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"service_extensions_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android textfield_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"textfield_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android tiles_scroll_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"tiles_scroll_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
       expiration_secs: 43200
       caches {
         name: "android_sdk"
@@ -22868,54 +24596,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging channels_integration_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"channels_integration_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging channels_integration_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -22955,102 +24635,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging color_filter_and_fade_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"color_filter_and_fade_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging complex_layout__start_up"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"complex_layout__start_up\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23147,102 +24731,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging complex_layout_scroll_perf__memory"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"complex_layout_scroll_perf__memory\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging complex_layout_scroll_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"complex_layout_scroll_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23288,294 +24776,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging cubic_bezier_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"cubic_bezier_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"cubic_bezier_perf_sksl_warmup__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging cull_opacity_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"cull_opacity_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging drive_perf_debug_warning"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"drive_perf_debug_warning\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging embedded_android_views_integration_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"embedded_android_views_integration_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging external_ui_integration_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"external_ui_integration_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging external_ui_integration_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23615,150 +24815,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging fading_child_animation_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"fading_child_animation_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging fast_scroll_large_images__memory"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"fast_scroll_large_images__memory\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging flavors_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"flavors_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23990,54 +25046,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging flutter_view__start_up"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"flutter_view__start_up\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging flutter_view_ios__start_up"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -24077,150 +25085,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging fullscreen_textfield_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"fullscreen_textfield_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging hello_world__memory"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"hello_world__memory\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging hello_world_android__compile"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"hello_world_android__compile\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -24272,102 +25136,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging home_scroll_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"home_scroll_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging hot_mode_dev_cycle__benchmark"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"hot_mode_dev_cycle__benchmark\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -24407,150 +25175,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging hybrid_android_views_integration_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"hybrid_android_views_integration_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"imagefiltered_transform_animation_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging integration_ui_driver"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"integration_ui_driver\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -24731,150 +25355,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging integration_ui_keyboard_resize"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"integration_ui_keyboard_resize\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging integration_ui_screenshot"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"integration_ui_screenshot\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging integration_ui_textfield"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"integration_ui_textfield\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -25151,54 +25631,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging microbenchmarks"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"microbenchmarks\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging microbenchmarks_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -25244,54 +25676,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging new_gallery__transition_perf"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"new_gallery__transition_perf\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging new_gallery_ios__transition_perf"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -25331,102 +25715,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging picture_cache_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"picture_cache_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging platform_channel_sample_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"platform_channel_sample_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -25523,54 +25811,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging platform_interaction_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"platform_interaction_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging platform_interaction_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -25610,54 +25850,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging platform_view__start_up"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"platform_view__start_up\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -25799,102 +25991,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac_staging run_release_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"run_release_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging service_extensions_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"service_extensions_test\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac_staging simple_animation_perf_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -26024,102 +26120,6 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging textfield_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"textfield_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac_staging tiles_scroll_perf__timeline_summary"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_os:N"
-      dimensions: "os:Mac"
-      dimensions: "pool:luci.flutter.staging"
-      recipe {
-        name: "devicelab/devicelab_drone"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "task_name:\"tiles_scroll_perf__timeline_summary\""
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      expiration_secs: 43200
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -22634,6 +22634,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging android_plugin_example_app_build_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"android_plugin_example_app_build_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging android_semantics_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"android_semantics_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging backdrop_filter_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"backdrop_filter_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging backdrop_filter_perf_ios__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -22724,6 +22868,54 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging channels_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"channels_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging channels_integration_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -22763,6 +22955,102 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging color_filter_and_fade_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"color_filter_and_fade_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging complex_layout__start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"complex_layout__start_up\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -22859,6 +23147,102 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging complex_layout_scroll_perf__memory"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"complex_layout_scroll_perf__memory\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging complex_layout_scroll_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"complex_layout_scroll_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -22904,6 +23288,294 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging cubic_bezier_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"cubic_bezier_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"cubic_bezier_perf_sksl_warmup__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging cull_opacity_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"cull_opacity_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging drive_perf_debug_warning"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"drive_perf_debug_warning\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging embedded_android_views_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"embedded_android_views_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging external_ui_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"external_ui_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging external_ui_integration_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -22943,6 +23615,150 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging fading_child_animation_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"fading_child_animation_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging fast_scroll_large_images__memory"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"fast_scroll_large_images__memory\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging flavors_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"flavors_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23174,6 +23990,54 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging flutter_view__start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"flutter_view__start_up\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging flutter_view_ios__start_up"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23213,6 +24077,150 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging fullscreen_textfield_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"fullscreen_textfield_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging hello_world__memory"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hello_world__memory\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging hello_world_android__compile"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hello_world_android__compile\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23264,6 +24272,102 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging home_scroll_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"home_scroll_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging hot_mode_dev_cycle__benchmark"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hot_mode_dev_cycle__benchmark\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23303,6 +24407,150 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging hybrid_android_views_integration_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"hybrid_android_views_integration_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"imagefiltered_transform_animation_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging integration_ui_driver"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_driver\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23483,6 +24731,150 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging integration_ui_keyboard_resize"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_keyboard_resize\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging integration_ui_screenshot"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_screenshot\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging integration_ui_textfield"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"integration_ui_textfield\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23759,6 +25151,54 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging microbenchmarks"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"microbenchmarks\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging microbenchmarks_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23804,6 +25244,54 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging new_gallery__transition_perf"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"new_gallery__transition_perf\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging new_gallery_ios__transition_perf"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23843,6 +25331,102 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging picture_cache_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"picture_cache_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging platform_channel_sample_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"platform_channel_sample_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -23939,6 +25523,54 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging platform_interaction_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"platform_interaction_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging platform_interaction_test_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -23978,6 +25610,54 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging platform_view__start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"platform_view__start_up\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
@@ -24119,6 +25799,102 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_staging run_release_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"run_release_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging service_extensions_test"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"service_extensions_test\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_staging simple_animation_perf_ios"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:iOS"
@@ -24248,6 +26024,102 @@ buckets {
       caches {
         name: "xcode_binary"
         path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging textfield_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"textfield_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_staging tiles_scroll_perf__timeline_summary"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.staging"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"tiles_scroll_perf__timeline_summary\""
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 3600
+      expiration_secs: 43200
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
       }
       build_numbers: YES
       service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1957,197 +1957,197 @@ consoles {
     short_name: "tspit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging android_plugin_example_app_build_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android android_plugin_example_app_build_test"
     category: "Mac_android"
     short_name: "apeab"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging android_semantics_integration_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android android_semantics_integration_test"
     category: "Mac_android"
     short_name: "asit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging backdrop_filter_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android backdrop_filter_perf__timeline_summary"
     category: "Mac_android"
     short_name: "bfpts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging channels_integration_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android channels_integration_test"
     category: "Mac_android"
     short_name: "cit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging color_filter_and_fade_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android color_filter_and_fade_perf__timeline_summary"
     category: "Mac_android"
     short_name: "cfafp"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging complex_layout_scroll_perf__memory"
+    name: "buildbucket/luci.flutter.prod/Mac_android complex_layout_scroll_perf__memory"
     category: "Mac_android"
     short_name: "clspm"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging complex_layout_scroll_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android complex_layout_scroll_perf__timeline_summary"
     category: "Mac_android"
     short_name: "clspt"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging complex_layout__start_up"
+    name: "buildbucket/luci.flutter.prod/Mac_android complex_layout__start_up"
     category: "Mac_android"
     short_name: "clsu"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary"
     category: "Mac_android"
     short_name: "cbpsw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging cubic_bezier_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android cubic_bezier_perf__timeline_summary"
     category: "Mac_android"
     short_name: "cbpts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging cull_opacity_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android cull_opacity_perf__timeline_summary"
     category: "Mac_android"
     short_name: "copts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging drive_perf_debug_warning"
+    name: "buildbucket/luci.flutter.prod/Mac_android drive_perf_debug_warning"
     category: "Mac_android"
     short_name: "dpdw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging embedded_android_views_integration_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android embedded_android_views_integration_test"
     category: "Mac_android"
     short_name: "eavit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging external_ui_integration_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android external_ui_integration_test"
     category: "Mac_android"
     short_name: "euit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging fading_child_animation_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android fading_child_animation_perf__timeline_summary"
     category: "Mac_android"
     short_name: "fcapt"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging fast_scroll_large_images__memory"
+    name: "buildbucket/luci.flutter.prod/Mac_android fast_scroll_large_images__memory"
     category: "Mac_android"
     short_name: "fslim"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging flavors_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android flavors_test"
     category: "Mac_android"
     short_name: "ft"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging flutter_view__start_up"
+    name: "buildbucket/luci.flutter.prod/Mac_android flutter_view__start_up"
     category: "Mac_android"
     short_name: "fvsu"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging fullscreen_textfield_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android fullscreen_textfield_perf__timeline_summary"
     category: "Mac_android"
     short_name: "ftpts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging hello_world_android__compile"
+    name: "buildbucket/luci.flutter.prod/Mac_android hello_world_android__compile"
     category: "Mac_android"
     short_name: "hwac"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging hello_world__memory"
+    name: "buildbucket/luci.flutter.prod/Mac_android hello_world__memory"
     category: "Mac_android"
     short_name: "hwm"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging home_scroll_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android home_scroll_perf__timeline_summary"
     category: "Mac_android"
     short_name: "hspts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging hot_mode_dev_cycle__benchmark"
+    name: "buildbucket/luci.flutter.prod/Mac_android hot_mode_dev_cycle__benchmark"
     category: "Mac_android"
     short_name: "hmdcb"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging hybrid_android_views_integration_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android hybrid_android_views_integration_test"
     category: "Mac_android"
     short_name: "havit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android imagefiltered_transform_animation_perf__timeline_summary"
     category: "Mac_android"
     short_name: "itapt"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_driver"
+    name: "buildbucket/luci.flutter.prod/Mac_android integration_ui_driver"
     category: "Mac_android"
     short_name: "iud"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_keyboard_resize"
+    name: "buildbucket/luci.flutter.prod/Mac_android integration_ui_keyboard_resize"
     category: "Mac_android"
     short_name: "iukr"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_screenshot"
+    name: "buildbucket/luci.flutter.prod/Mac_android integration_ui_screenshot"
     category: "Mac_android"
     short_name: "ius"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_textfield"
+    name: "buildbucket/luci.flutter.prod/Mac_android integration_ui_textfield"
     category: "Mac_android"
     short_name: "iut"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging microbenchmarks"
+    name: "buildbucket/luci.flutter.prod/Mac_android microbenchmarks"
     category: "Mac_android"
     short_name: "m"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging new_gallery__transition_perf"
+    name: "buildbucket/luci.flutter.prod/Mac_android new_gallery__transition_perf"
     category: "Mac_android"
     short_name: "ngtp"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging picture_cache_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android picture_cache_perf__timeline_summary"
     category: "Mac_android"
     short_name: "pcpts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging platform_channel_sample_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android platform_channel_sample_test"
     category: "Mac_android"
     short_name: "pcst"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging platform_interaction_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android platform_interaction_test"
     category: "Mac_android"
     short_name: "pit"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging platform_view__start_up"
+    name: "buildbucket/luci.flutter.prod/Mac_android platform_view__start_up"
     category: "Mac_android"
     short_name: "pvsu"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging run_release_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android run_release_test"
     category: "Mac_android"
     short_name: "rrt"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging service_extensions_test"
+    name: "buildbucket/luci.flutter.prod/Mac_android service_extensions_test"
     category: "Mac_android"
     short_name: "set"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging textfield_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android textfield_perf__timeline_summary"
     category: "Mac_android"
     short_name: "tpts"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac_staging tiles_scroll_perf__timeline_summary"
+    name: "buildbucket/luci.flutter.prod/Mac_android tiles_scroll_perf__timeline_summary"
     category: "Mac_android"
     short_name: "tspts"
   }

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -1957,6 +1957,201 @@ consoles {
     short_name: "tspit"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging android_plugin_example_app_build_test"
+    category: "Mac_android"
+    short_name: "apeab"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging android_semantics_integration_test"
+    category: "Mac_android"
+    short_name: "asit"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging backdrop_filter_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "bfpts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging channels_integration_test"
+    category: "Mac_android"
+    short_name: "cit"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging color_filter_and_fade_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "cfafp"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging complex_layout_scroll_perf__memory"
+    category: "Mac_android"
+    short_name: "clspm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging complex_layout_scroll_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "clspt"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging complex_layout__start_up"
+    category: "Mac_android"
+    short_name: "clsu"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+    category: "Mac_android"
+    short_name: "cbpsw"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging cubic_bezier_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "cbpts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging cull_opacity_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "copts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging drive_perf_debug_warning"
+    category: "Mac_android"
+    short_name: "dpdw"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging embedded_android_views_integration_test"
+    category: "Mac_android"
+    short_name: "eavit"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging external_ui_integration_test"
+    category: "Mac_android"
+    short_name: "euit"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging fading_child_animation_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "fcapt"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging fast_scroll_large_images__memory"
+    category: "Mac_android"
+    short_name: "fslim"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging flavors_test"
+    category: "Mac_android"
+    short_name: "ft"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging flutter_view__start_up"
+    category: "Mac_android"
+    short_name: "fvsu"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging fullscreen_textfield_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "ftpts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging hello_world_android__compile"
+    category: "Mac_android"
+    short_name: "hwac"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging hello_world__memory"
+    category: "Mac_android"
+    short_name: "hwm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging home_scroll_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "hspts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging hot_mode_dev_cycle__benchmark"
+    category: "Mac_android"
+    short_name: "hmdcb"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging hybrid_android_views_integration_test"
+    category: "Mac_android"
+    short_name: "havit"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "itapt"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_driver"
+    category: "Mac_android"
+    short_name: "iud"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_keyboard_resize"
+    category: "Mac_android"
+    short_name: "iukr"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_screenshot"
+    category: "Mac_android"
+    short_name: "ius"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging integration_ui_textfield"
+    category: "Mac_android"
+    short_name: "iut"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging microbenchmarks"
+    category: "Mac_android"
+    short_name: "m"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging new_gallery__transition_perf"
+    category: "Mac_android"
+    short_name: "ngtp"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging picture_cache_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "pcpts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging platform_channel_sample_test"
+    category: "Mac_android"
+    short_name: "pcst"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging platform_interaction_test"
+    category: "Mac_android"
+    short_name: "pit"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging platform_view__start_up"
+    category: "Mac_android"
+    short_name: "pvsu"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging run_release_test"
+    category: "Mac_android"
+    short_name: "rrt"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging service_extensions_test"
+    category: "Mac_android"
+    short_name: "set"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging textfield_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "tpts"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_staging tiles_scroll_perf__timeline_summary"
+    category: "Mac_android"
+    short_name: "tspts"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Linux_staging analyzer_benchmark"
     category: "Linux"
     short_name: "ab"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -5016,6 +5016,39 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging android_plugin_example_app_build_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging android_semantics_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging backdrop_filter_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging backdrop_filter_perf_ios__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5038,7 +5071,40 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging channels_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging channels_integration_test_ios"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging color_filter_and_fade_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging complex_layout__start_up"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5071,6 +5137,28 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging complex_layout_scroll_perf__memory"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging complex_layout_scroll_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5082,7 +5170,106 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging cubic_bezier_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging cull_opacity_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging drive_perf_debug_warning"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging embedded_android_views_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging external_ui_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging external_ui_integration_test_ios"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging fading_child_animation_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging fast_scroll_large_images__memory"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging flavors_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5148,7 +5335,51 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging flutter_view__start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging flutter_view_ios__start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging fullscreen_textfield_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging hello_world__memory"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging hello_world_android__compile"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5170,7 +5401,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging home_scroll_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging hot_mode_dev_cycle__benchmark"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging hybrid_android_views_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging integration_ui_driver"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5215,6 +5501,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac_staging integration_ui_ios_textfield"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging integration_ui_keyboard_resize"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging integration_ui_screenshot"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging integration_ui_textfield"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5291,6 +5610,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging microbenchmarks"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging microbenchmarks_ios"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5302,7 +5632,40 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging new_gallery__transition_perf"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging new_gallery_ios__transition_perf"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging picture_cache_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging platform_channel_sample_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5335,7 +5698,29 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging platform_interaction_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging platform_interaction_test_ios"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging platform_view__start_up"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5379,6 +5764,28 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_staging run_release_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging service_extensions_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_staging simple_animation_perf_ios"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5402,6 +5809,28 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac_staging smoke_catalina_start_up_ios"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging textfield_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_staging tiles_scroll_perf__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -5016,7 +5016,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging android_plugin_example_app_build_test"
+    name: "Mac_android android_plugin_example_app_build_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5027,7 +5027,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging android_semantics_integration_test"
+    name: "Mac_android android_semantics_integration_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5038,7 +5038,403 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging backdrop_filter_perf__timeline_summary"
+    name: "Mac_android backdrop_filter_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android channels_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android color_filter_and_fade_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android complex_layout__start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android complex_layout_scroll_perf__memory"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android complex_layout_scroll_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android cubic_bezier_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android cull_opacity_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android drive_perf_debug_warning"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android embedded_android_views_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android external_ui_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android fading_child_animation_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android fast_scroll_large_images__memory"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android flavors_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android flutter_view__start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android fullscreen_textfield_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android hello_world__memory"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android hello_world_android__compile"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android home_scroll_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android hot_mode_dev_cycle__benchmark"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android hybrid_android_views_integration_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android imagefiltered_transform_animation_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android integration_ui_driver"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android integration_ui_keyboard_resize"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android integration_ui_screenshot"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android integration_ui_textfield"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android microbenchmarks"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android new_gallery__transition_perf"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android picture_cache_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android platform_channel_sample_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android platform_interaction_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android platform_view__start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android run_release_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android service_extensions_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android textfield_perf__timeline_summary"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android tiles_scroll_perf__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5071,40 +5467,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging channels_integration_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging channels_integration_test_ios"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging color_filter_and_fade_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging complex_layout__start_up"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5137,28 +5500,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging complex_layout_scroll_perf__memory"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging complex_layout_scroll_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5170,106 +5511,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging cubic_bezier_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging cull_opacity_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging drive_perf_debug_warning"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging embedded_android_views_integration_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging external_ui_integration_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging external_ui_integration_test_ios"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging fading_child_animation_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging fast_scroll_large_images__memory"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging flavors_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5335,51 +5577,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging flutter_view__start_up"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging flutter_view_ios__start_up"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging fullscreen_textfield_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging hello_world__memory"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging hello_world_android__compile"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5401,62 +5599,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging home_scroll_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging hot_mode_dev_cycle__benchmark"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging hybrid_android_views_integration_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging integration_ui_driver"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5501,39 +5644,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac_staging integration_ui_ios_textfield"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging integration_ui_keyboard_resize"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging integration_ui_screenshot"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging integration_ui_textfield"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5610,17 +5720,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging microbenchmarks"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging microbenchmarks_ios"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5632,40 +5731,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging new_gallery__transition_perf"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging new_gallery_ios__transition_perf"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging picture_cache_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging platform_channel_sample_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5698,29 +5764,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging platform_interaction_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging platform_interaction_test_ios"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging platform_view__start_up"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5764,28 +5808,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac_staging run_release_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging service_extensions_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac_staging simple_animation_perf_ios"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5809,28 +5831,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac_staging smoke_catalina_start_up_ios"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging textfield_perf__timeline_summary"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac_staging tiles_scroll_perf__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -6324,7 +6324,7 @@ job {
   }
 }
 job {
-  id: "Mac_staging android_plugin_example_app_build_test"
+  id: "Mac_android android_plugin_example_app_build_test"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
@@ -6334,11 +6334,11 @@ job {
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
-    builder: "Mac_staging android_plugin_example_app_build_test"
+    builder: "Mac_android android_plugin_example_app_build_test"
   }
 }
 job {
-  id: "Mac_staging android_semantics_integration_test"
+  id: "Mac_android android_semantics_integration_test"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
@@ -6348,11 +6348,11 @@ job {
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
-    builder: "Mac_staging android_semantics_integration_test"
+    builder: "Mac_android android_semantics_integration_test"
   }
 }
 job {
-  id: "Mac_staging backdrop_filter_perf__timeline_summary"
+  id: "Mac_android backdrop_filter_perf__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
@@ -6362,7 +6362,511 @@ job {
   buildbucket {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
-    builder: "Mac_staging backdrop_filter_perf__timeline_summary"
+    builder: "Mac_android backdrop_filter_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android channels_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android channels_integration_test"
+  }
+}
+job {
+  id: "Mac_android color_filter_and_fade_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android color_filter_and_fade_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android complex_layout__start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android complex_layout__start_up"
+  }
+}
+job {
+  id: "Mac_android complex_layout_scroll_perf__memory"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android complex_layout_scroll_perf__memory"
+  }
+}
+job {
+  id: "Mac_android complex_layout_scroll_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android complex_layout_scroll_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android cubic_bezier_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android cubic_bezier_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android cull_opacity_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android cull_opacity_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android drive_perf_debug_warning"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android drive_perf_debug_warning"
+  }
+}
+job {
+  id: "Mac_android embedded_android_views_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android embedded_android_views_integration_test"
+  }
+}
+job {
+  id: "Mac_android external_ui_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android external_ui_integration_test"
+  }
+}
+job {
+  id: "Mac_android fading_child_animation_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android fading_child_animation_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android fast_scroll_large_images__memory"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android fast_scroll_large_images__memory"
+  }
+}
+job {
+  id: "Mac_android flavors_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android flavors_test"
+  }
+}
+job {
+  id: "Mac_android flutter_view__start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android flutter_view__start_up"
+  }
+}
+job {
+  id: "Mac_android fullscreen_textfield_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android fullscreen_textfield_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android hello_world__memory"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android hello_world__memory"
+  }
+}
+job {
+  id: "Mac_android hello_world_android__compile"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android hello_world_android__compile"
+  }
+}
+job {
+  id: "Mac_android home_scroll_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android home_scroll_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android hot_mode_dev_cycle__benchmark"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android hot_mode_dev_cycle__benchmark"
+  }
+}
+job {
+  id: "Mac_android hybrid_android_views_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android hybrid_android_views_integration_test"
+  }
+}
+job {
+  id: "Mac_android imagefiltered_transform_animation_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android imagefiltered_transform_animation_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android integration_ui_driver"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android integration_ui_driver"
+  }
+}
+job {
+  id: "Mac_android integration_ui_keyboard_resize"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android integration_ui_keyboard_resize"
+  }
+}
+job {
+  id: "Mac_android integration_ui_screenshot"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android integration_ui_screenshot"
+  }
+}
+job {
+  id: "Mac_android integration_ui_textfield"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android integration_ui_textfield"
+  }
+}
+job {
+  id: "Mac_android microbenchmarks"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android microbenchmarks"
+  }
+}
+job {
+  id: "Mac_android new_gallery__transition_perf"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android new_gallery__transition_perf"
+  }
+}
+job {
+  id: "Mac_android picture_cache_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android picture_cache_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android platform_channel_sample_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android platform_channel_sample_test"
+  }
+}
+job {
+  id: "Mac_android platform_interaction_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android platform_interaction_test"
+  }
+}
+job {
+  id: "Mac_android platform_view__start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android platform_view__start_up"
+  }
+}
+job {
+  id: "Mac_android run_release_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android run_release_test"
+  }
+}
+job {
+  id: "Mac_android service_extensions_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android service_extensions_test"
+  }
+}
+job {
+  id: "Mac_android textfield_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android textfield_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_android tiles_scroll_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android tiles_scroll_perf__timeline_summary"
   }
 }
 job {
@@ -6394,20 +6898,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging channels_integration_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging channels_integration_test"
-  }
-}
-job {
   id: "Mac_staging channels_integration_test_ios"
   acl_sets: "prod"
   triggering_policy {
@@ -6419,34 +6909,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging channels_integration_test_ios"
-  }
-}
-job {
-  id: "Mac_staging color_filter_and_fade_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging color_filter_and_fade_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging complex_layout__start_up"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging complex_layout__start_up"
   }
 }
 job {
@@ -6478,34 +6940,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging complex_layout_scroll_perf__memory"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging complex_layout_scroll_perf__memory"
-  }
-}
-job {
-  id: "Mac_staging complex_layout_scroll_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging complex_layout_scroll_perf__timeline_summary"
-  }
-}
-job {
   id: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
@@ -6520,90 +6954,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging cubic_bezier_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging cubic_bezier_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging cull_opacity_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging cull_opacity_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging drive_perf_debug_warning"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging drive_perf_debug_warning"
-  }
-}
-job {
-  id: "Mac_staging embedded_android_views_integration_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging embedded_android_views_integration_test"
-  }
-}
-job {
-  id: "Mac_staging external_ui_integration_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging external_ui_integration_test"
-  }
-}
-job {
   id: "Mac_staging external_ui_integration_test_ios"
   acl_sets: "prod"
   triggering_policy {
@@ -6615,48 +6965,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging external_ui_integration_test_ios"
-  }
-}
-job {
-  id: "Mac_staging fading_child_animation_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging fading_child_animation_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging fast_scroll_large_images__memory"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging fast_scroll_large_images__memory"
-  }
-}
-job {
-  id: "Mac_staging flavors_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging flavors_test"
   }
 }
 job {
@@ -6730,20 +7038,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging flutter_view__start_up"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging flutter_view__start_up"
-  }
-}
-job {
   id: "Mac_staging flutter_view_ios__start_up"
   acl_sets: "prod"
   triggering_policy {
@@ -6755,48 +7049,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging flutter_view_ios__start_up"
-  }
-}
-job {
-  id: "Mac_staging fullscreen_textfield_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging fullscreen_textfield_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging hello_world__memory"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging hello_world__memory"
-  }
-}
-job {
-  id: "Mac_staging hello_world_android__compile"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging hello_world_android__compile"
   }
 }
 job {
@@ -6814,34 +7066,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging home_scroll_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging home_scroll_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging hot_mode_dev_cycle__benchmark"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging hot_mode_dev_cycle__benchmark"
-  }
-}
-job {
   id: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
   acl_sets: "prod"
   triggering_policy {
@@ -6853,48 +7077,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
-  }
-}
-job {
-  id: "Mac_staging hybrid_android_views_integration_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging hybrid_android_views_integration_test"
-  }
-}
-job {
-  id: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging integration_ui_driver"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging integration_ui_driver"
   }
 }
 job {
@@ -6951,48 +7133,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging integration_ui_ios_textfield"
-  }
-}
-job {
-  id: "Mac_staging integration_ui_keyboard_resize"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging integration_ui_keyboard_resize"
-  }
-}
-job {
-  id: "Mac_staging integration_ui_screenshot"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging integration_ui_screenshot"
-  }
-}
-job {
-  id: "Mac_staging integration_ui_textfield"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging integration_ui_textfield"
   }
 }
 job {
@@ -7080,20 +7220,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging microbenchmarks"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging microbenchmarks"
-  }
-}
-job {
   id: "Mac_staging microbenchmarks_ios"
   acl_sets: "prod"
   triggering_policy {
@@ -7108,20 +7234,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging new_gallery__transition_perf"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging new_gallery__transition_perf"
-  }
-}
-job {
   id: "Mac_staging new_gallery_ios__transition_perf"
   acl_sets: "prod"
   triggering_policy {
@@ -7133,34 +7245,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging new_gallery_ios__transition_perf"
-  }
-}
-job {
-  id: "Mac_staging picture_cache_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging picture_cache_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging platform_channel_sample_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging platform_channel_sample_test"
   }
 }
 job {
@@ -7192,20 +7276,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging platform_interaction_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging platform_interaction_test"
-  }
-}
-job {
   id: "Mac_staging platform_interaction_test_ios"
   acl_sets: "prod"
   triggering_policy {
@@ -7217,20 +7287,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging platform_interaction_test_ios"
-  }
-}
-job {
-  id: "Mac_staging platform_view__start_up"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging platform_view__start_up"
   }
 }
 job {
@@ -7276,34 +7332,6 @@ job {
   }
 }
 job {
-  id: "Mac_staging run_release_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging run_release_test"
-  }
-}
-job {
-  id: "Mac_staging service_extensions_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging service_extensions_test"
-  }
-}
-job {
   id: "Mac_staging simple_animation_perf_ios"
   acl_sets: "prod"
   triggering_policy {
@@ -7343,34 +7371,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_staging smoke_catalina_start_up_ios"
-  }
-}
-job {
-  id: "Mac_staging textfield_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging textfield_perf__timeline_summary"
-  }
-}
-job {
-  id: "Mac_staging tiles_scroll_perf__timeline_summary"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 1
-    max_batch_size: 20
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac_staging tiles_scroll_perf__timeline_summary"
   }
 }
 job {
@@ -8980,81 +8980,81 @@ trigger {
   triggers: "Linux_staging android_obfuscate_test"
   triggers: "Linux_staging android_view_scroll_perf__timeline_summary"
   triggers: "Linux_staging animated_placeholder_perf__e2e_summary"
-  triggers: "Mac_staging android_plugin_example_app_build_test"
-  triggers: "Mac_staging android_semantics_integration_test"
-  triggers: "Mac_staging backdrop_filter_perf__timeline_summary"
+  triggers: "Mac_android android_plugin_example_app_build_test"
+  triggers: "Mac_android android_semantics_integration_test"
+  triggers: "Mac_android backdrop_filter_perf__timeline_summary"
+  triggers: "Mac_android channels_integration_test"
+  triggers: "Mac_android color_filter_and_fade_perf__timeline_summary"
+  triggers: "Mac_android complex_layout__start_up"
+  triggers: "Mac_android complex_layout_scroll_perf__memory"
+  triggers: "Mac_android complex_layout_scroll_perf__timeline_summary"
+  triggers: "Mac_android cubic_bezier_perf__timeline_summary"
+  triggers: "Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary"
+  triggers: "Mac_android cull_opacity_perf__timeline_summary"
+  triggers: "Mac_android drive_perf_debug_warning"
+  triggers: "Mac_android embedded_android_views_integration_test"
+  triggers: "Mac_android external_ui_integration_test"
+  triggers: "Mac_android fading_child_animation_perf__timeline_summary"
+  triggers: "Mac_android fast_scroll_large_images__memory"
+  triggers: "Mac_android flavors_test"
+  triggers: "Mac_android flutter_view__start_up"
+  triggers: "Mac_android fullscreen_textfield_perf__timeline_summary"
+  triggers: "Mac_android hello_world__memory"
+  triggers: "Mac_android hello_world_android__compile"
+  triggers: "Mac_android home_scroll_perf__timeline_summary"
+  triggers: "Mac_android hot_mode_dev_cycle__benchmark"
+  triggers: "Mac_android hybrid_android_views_integration_test"
+  triggers: "Mac_android imagefiltered_transform_animation_perf__timeline_summary"
+  triggers: "Mac_android integration_ui_driver"
+  triggers: "Mac_android integration_ui_keyboard_resize"
+  triggers: "Mac_android integration_ui_screenshot"
+  triggers: "Mac_android integration_ui_textfield"
+  triggers: "Mac_android microbenchmarks"
+  triggers: "Mac_android new_gallery__transition_perf"
+  triggers: "Mac_android picture_cache_perf__timeline_summary"
+  triggers: "Mac_android platform_channel_sample_test"
+  triggers: "Mac_android platform_interaction_test"
+  triggers: "Mac_android platform_view__start_up"
+  triggers: "Mac_android run_release_test"
+  triggers: "Mac_android service_extensions_test"
+  triggers: "Mac_android textfield_perf__timeline_summary"
+  triggers: "Mac_android tiles_scroll_perf__timeline_summary"
   triggers: "Mac_staging backdrop_filter_perf_ios__timeline_summary"
   triggers: "Mac_staging basic_material_app_ios__compile"
-  triggers: "Mac_staging channels_integration_test"
   triggers: "Mac_staging channels_integration_test_ios"
-  triggers: "Mac_staging color_filter_and_fade_perf__timeline_summary"
-  triggers: "Mac_staging complex_layout__start_up"
   triggers: "Mac_staging complex_layout_ios__compile"
   triggers: "Mac_staging complex_layout_ios__start_up"
-  triggers: "Mac_staging complex_layout_scroll_perf__memory"
-  triggers: "Mac_staging complex_layout_scroll_perf__timeline_summary"
   triggers: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
-  triggers: "Mac_staging cubic_bezier_perf__timeline_summary"
-  triggers: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
-  triggers: "Mac_staging cull_opacity_perf__timeline_summary"
-  triggers: "Mac_staging drive_perf_debug_warning"
-  triggers: "Mac_staging embedded_android_views_integration_test"
-  triggers: "Mac_staging external_ui_integration_test"
   triggers: "Mac_staging external_ui_integration_test_ios"
-  triggers: "Mac_staging fading_child_animation_perf__timeline_summary"
-  triggers: "Mac_staging fast_scroll_large_images__memory"
-  triggers: "Mac_staging flavors_test"
   triggers: "Mac_staging flavors_test_ios"
   triggers: "Mac_staging flutter_gallery__transition_perf_e2e_ios"
   triggers: "Mac_staging flutter_gallery_ios__compile"
   triggers: "Mac_staging flutter_gallery_ios__start_up"
   triggers: "Mac_staging flutter_gallery_ios__transition_perf"
-  triggers: "Mac_staging flutter_view__start_up"
   triggers: "Mac_staging flutter_view_ios__start_up"
-  triggers: "Mac_staging fullscreen_textfield_perf__timeline_summary"
-  triggers: "Mac_staging hello_world__memory"
-  triggers: "Mac_staging hello_world_android__compile"
   triggers: "Mac_staging hello_world_ios__compile"
-  triggers: "Mac_staging home_scroll_perf__timeline_summary"
-  triggers: "Mac_staging hot_mode_dev_cycle__benchmark"
   triggers: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
-  triggers: "Mac_staging hybrid_android_views_integration_test"
-  triggers: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
-  triggers: "Mac_staging integration_ui_driver"
   triggers: "Mac_staging integration_ui_ios_driver"
   triggers: "Mac_staging integration_ui_ios_keyboard_resize"
   triggers: "Mac_staging integration_ui_ios_screenshot"
   triggers: "Mac_staging integration_ui_ios_textfield"
-  triggers: "Mac_staging integration_ui_keyboard_resize"
-  triggers: "Mac_staging integration_ui_screenshot"
-  triggers: "Mac_staging integration_ui_textfield"
   triggers: "Mac_staging ios_app_with_extensions_test"
   triggers: "Mac_staging ios_content_validation_test"
   triggers: "Mac_staging ios_defines_test"
   triggers: "Mac_staging ios_platform_view_tests"
   triggers: "Mac_staging large_image_changer_perf_ios"
   triggers: "Mac_staging macos_chrome_dev_mode"
-  triggers: "Mac_staging microbenchmarks"
   triggers: "Mac_staging microbenchmarks_ios"
-  triggers: "Mac_staging new_gallery__transition_perf"
   triggers: "Mac_staging new_gallery_ios__transition_perf"
-  triggers: "Mac_staging picture_cache_perf__timeline_summary"
-  triggers: "Mac_staging platform_channel_sample_test"
   triggers: "Mac_staging platform_channel_sample_test_ios"
   triggers: "Mac_staging platform_channel_sample_test_swift"
-  triggers: "Mac_staging platform_interaction_test"
   triggers: "Mac_staging platform_interaction_test_ios"
-  triggers: "Mac_staging platform_view__start_up"
   triggers: "Mac_staging platform_view_ios__start_up"
   triggers: "Mac_staging platform_views_scroll_perf_ios__timeline_summary"
   triggers: "Mac_staging post_backdrop_filter_perf_ios__timeline_summary"
-  triggers: "Mac_staging run_release_test"
-  triggers: "Mac_staging service_extensions_test"
   triggers: "Mac_staging simple_animation_perf_ios"
   triggers: "Mac_staging smoke_catalina_hot_mode_dev_cycle_ios__benchmark"
   triggers: "Mac_staging smoke_catalina_start_up_ios"
-  triggers: "Mac_staging textfield_perf__timeline_summary"
-  triggers: "Mac_staging tiles_scroll_perf__timeline_summary"
   triggers: "Mac_staging tiles_scroll_perf_ios__timeline_summary"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -4798,7 +4798,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -4812,7 +4812,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -4826,7 +4826,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -4840,7 +4840,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -4854,7 +4854,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6324,11 +6324,53 @@ job {
   }
 }
 job {
+  id: "Mac_staging android_plugin_example_app_build_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging android_plugin_example_app_build_test"
+  }
+}
+job {
+  id: "Mac_staging android_semantics_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging android_semantics_integration_test"
+  }
+}
+job {
+  id: "Mac_staging backdrop_filter_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging backdrop_filter_perf__timeline_summary"
+  }
+}
+job {
   id: "Mac_staging backdrop_filter_perf_ios__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6342,7 +6384,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6352,11 +6394,25 @@ job {
   }
 }
 job {
+  id: "Mac_staging channels_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging channels_integration_test"
+  }
+}
+job {
   id: "Mac_staging channels_integration_test_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6366,11 +6422,39 @@ job {
   }
 }
 job {
+  id: "Mac_staging color_filter_and_fade_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging color_filter_and_fade_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging complex_layout__start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging complex_layout__start_up"
+  }
+}
+job {
   id: "Mac_staging complex_layout_ios__compile"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6384,7 +6468,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6394,11 +6478,39 @@ job {
   }
 }
 job {
+  id: "Mac_staging complex_layout_scroll_perf__memory"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging complex_layout_scroll_perf__memory"
+  }
+}
+job {
+  id: "Mac_staging complex_layout_scroll_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging complex_layout_scroll_perf__timeline_summary"
+  }
+}
+job {
   id: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6408,11 +6520,95 @@ job {
   }
 }
 job {
+  id: "Mac_staging cubic_bezier_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging cubic_bezier_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging cull_opacity_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging cull_opacity_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging drive_perf_debug_warning"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging drive_perf_debug_warning"
+  }
+}
+job {
+  id: "Mac_staging embedded_android_views_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging embedded_android_views_integration_test"
+  }
+}
+job {
+  id: "Mac_staging external_ui_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging external_ui_integration_test"
+  }
+}
+job {
   id: "Mac_staging external_ui_integration_test_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6422,11 +6618,53 @@ job {
   }
 }
 job {
+  id: "Mac_staging fading_child_animation_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging fading_child_animation_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging fast_scroll_large_images__memory"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging fast_scroll_large_images__memory"
+  }
+}
+job {
+  id: "Mac_staging flavors_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging flavors_test"
+  }
+}
+job {
   id: "Mac_staging flavors_test_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6440,7 +6678,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6454,7 +6692,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6468,7 +6706,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6482,7 +6720,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6492,11 +6730,25 @@ job {
   }
 }
 job {
+  id: "Mac_staging flutter_view__start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging flutter_view__start_up"
+  }
+}
+job {
   id: "Mac_staging flutter_view_ios__start_up"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6506,11 +6758,53 @@ job {
   }
 }
 job {
+  id: "Mac_staging fullscreen_textfield_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging fullscreen_textfield_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging hello_world__memory"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging hello_world__memory"
+  }
+}
+job {
+  id: "Mac_staging hello_world_android__compile"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging hello_world_android__compile"
+  }
+}
+job {
   id: "Mac_staging hello_world_ios__compile"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6520,11 +6814,39 @@ job {
   }
 }
 job {
+  id: "Mac_staging home_scroll_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging home_scroll_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging hot_mode_dev_cycle__benchmark"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging hot_mode_dev_cycle__benchmark"
+  }
+}
+job {
   id: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6534,11 +6856,53 @@ job {
   }
 }
 job {
+  id: "Mac_staging hybrid_android_views_integration_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging hybrid_android_views_integration_test"
+  }
+}
+job {
+  id: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging integration_ui_driver"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging integration_ui_driver"
+  }
+}
+job {
   id: "Mac_staging integration_ui_ios_driver"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6552,7 +6916,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6566,7 +6930,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6580,7 +6944,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6590,11 +6954,53 @@ job {
   }
 }
 job {
+  id: "Mac_staging integration_ui_keyboard_resize"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging integration_ui_keyboard_resize"
+  }
+}
+job {
+  id: "Mac_staging integration_ui_screenshot"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging integration_ui_screenshot"
+  }
+}
+job {
+  id: "Mac_staging integration_ui_textfield"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging integration_ui_textfield"
+  }
+}
+job {
   id: "Mac_staging ios_app_with_extensions_test"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6608,7 +7014,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6622,7 +7028,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6636,7 +7042,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6650,7 +7056,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6664,7 +7070,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6674,11 +7080,25 @@ job {
   }
 }
 job {
+  id: "Mac_staging microbenchmarks"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging microbenchmarks"
+  }
+}
+job {
   id: "Mac_staging microbenchmarks_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6688,11 +7108,25 @@ job {
   }
 }
 job {
+  id: "Mac_staging new_gallery__transition_perf"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging new_gallery__transition_perf"
+  }
+}
+job {
   id: "Mac_staging new_gallery_ios__transition_perf"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6702,11 +7136,39 @@ job {
   }
 }
 job {
+  id: "Mac_staging picture_cache_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging picture_cache_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging platform_channel_sample_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging platform_channel_sample_test"
+  }
+}
+job {
   id: "Mac_staging platform_channel_sample_test_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6720,7 +7182,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6730,11 +7192,25 @@ job {
   }
 }
 job {
+  id: "Mac_staging platform_interaction_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging platform_interaction_test"
+  }
+}
+job {
   id: "Mac_staging platform_interaction_test_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6744,11 +7220,25 @@ job {
   }
 }
 job {
+  id: "Mac_staging platform_view__start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging platform_view__start_up"
+  }
+}
+job {
   id: "Mac_staging platform_view_ios__start_up"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6762,7 +7252,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6776,7 +7266,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6786,11 +7276,39 @@ job {
   }
 }
 job {
+  id: "Mac_staging run_release_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging run_release_test"
+  }
+}
+job {
+  id: "Mac_staging service_extensions_test"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging service_extensions_test"
+  }
+}
+job {
   id: "Mac_staging simple_animation_perf_ios"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6804,7 +7322,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6818,7 +7336,7 @@ job {
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -6828,11 +7346,39 @@ job {
   }
 }
 job {
+  id: "Mac_staging textfield_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging textfield_perf__timeline_summary"
+  }
+}
+job {
+  id: "Mac_staging tiles_scroll_perf__timeline_summary"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 20
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_staging tiles_scroll_perf__timeline_summary"
+  }
+}
+job {
   id: "Mac_staging tiles_scroll_perf_ios__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
     kind: GREEDY_BATCHING
-    max_concurrent_invocations: 2
+    max_concurrent_invocations: 1
     max_batch_size: 20
   }
   buildbucket {
@@ -8434,42 +8980,81 @@ trigger {
   triggers: "Linux_staging android_obfuscate_test"
   triggers: "Linux_staging android_view_scroll_perf__timeline_summary"
   triggers: "Linux_staging animated_placeholder_perf__e2e_summary"
+  triggers: "Mac_staging android_plugin_example_app_build_test"
+  triggers: "Mac_staging android_semantics_integration_test"
+  triggers: "Mac_staging backdrop_filter_perf__timeline_summary"
   triggers: "Mac_staging backdrop_filter_perf_ios__timeline_summary"
   triggers: "Mac_staging basic_material_app_ios__compile"
+  triggers: "Mac_staging channels_integration_test"
   triggers: "Mac_staging channels_integration_test_ios"
+  triggers: "Mac_staging color_filter_and_fade_perf__timeline_summary"
+  triggers: "Mac_staging complex_layout__start_up"
   triggers: "Mac_staging complex_layout_ios__compile"
   triggers: "Mac_staging complex_layout_ios__start_up"
+  triggers: "Mac_staging complex_layout_scroll_perf__memory"
+  triggers: "Mac_staging complex_layout_scroll_perf__timeline_summary"
   triggers: "Mac_staging complex_layout_scroll_perf_ios__timeline_summary"
+  triggers: "Mac_staging cubic_bezier_perf__timeline_summary"
+  triggers: "Mac_staging cubic_bezier_perf_sksl_warmup__timeline_summary"
+  triggers: "Mac_staging cull_opacity_perf__timeline_summary"
+  triggers: "Mac_staging drive_perf_debug_warning"
+  triggers: "Mac_staging embedded_android_views_integration_test"
+  triggers: "Mac_staging external_ui_integration_test"
   triggers: "Mac_staging external_ui_integration_test_ios"
+  triggers: "Mac_staging fading_child_animation_perf__timeline_summary"
+  triggers: "Mac_staging fast_scroll_large_images__memory"
+  triggers: "Mac_staging flavors_test"
   triggers: "Mac_staging flavors_test_ios"
   triggers: "Mac_staging flutter_gallery__transition_perf_e2e_ios"
   triggers: "Mac_staging flutter_gallery_ios__compile"
   triggers: "Mac_staging flutter_gallery_ios__start_up"
   triggers: "Mac_staging flutter_gallery_ios__transition_perf"
+  triggers: "Mac_staging flutter_view__start_up"
   triggers: "Mac_staging flutter_view_ios__start_up"
+  triggers: "Mac_staging fullscreen_textfield_perf__timeline_summary"
+  triggers: "Mac_staging hello_world__memory"
+  triggers: "Mac_staging hello_world_android__compile"
   triggers: "Mac_staging hello_world_ios__compile"
+  triggers: "Mac_staging home_scroll_perf__timeline_summary"
+  triggers: "Mac_staging hot_mode_dev_cycle__benchmark"
   triggers: "Mac_staging hot_mode_dev_cycle_macos_target__benchmark"
+  triggers: "Mac_staging hybrid_android_views_integration_test"
+  triggers: "Mac_staging imagefiltered_transform_animation_perf__timeline_summary"
+  triggers: "Mac_staging integration_ui_driver"
   triggers: "Mac_staging integration_ui_ios_driver"
   triggers: "Mac_staging integration_ui_ios_keyboard_resize"
   triggers: "Mac_staging integration_ui_ios_screenshot"
   triggers: "Mac_staging integration_ui_ios_textfield"
+  triggers: "Mac_staging integration_ui_keyboard_resize"
+  triggers: "Mac_staging integration_ui_screenshot"
+  triggers: "Mac_staging integration_ui_textfield"
   triggers: "Mac_staging ios_app_with_extensions_test"
   triggers: "Mac_staging ios_content_validation_test"
   triggers: "Mac_staging ios_defines_test"
   triggers: "Mac_staging ios_platform_view_tests"
   triggers: "Mac_staging large_image_changer_perf_ios"
   triggers: "Mac_staging macos_chrome_dev_mode"
+  triggers: "Mac_staging microbenchmarks"
   triggers: "Mac_staging microbenchmarks_ios"
+  triggers: "Mac_staging new_gallery__transition_perf"
   triggers: "Mac_staging new_gallery_ios__transition_perf"
+  triggers: "Mac_staging picture_cache_perf__timeline_summary"
+  triggers: "Mac_staging platform_channel_sample_test"
   triggers: "Mac_staging platform_channel_sample_test_ios"
   triggers: "Mac_staging platform_channel_sample_test_swift"
+  triggers: "Mac_staging platform_interaction_test"
   triggers: "Mac_staging platform_interaction_test_ios"
+  triggers: "Mac_staging platform_view__start_up"
   triggers: "Mac_staging platform_view_ios__start_up"
   triggers: "Mac_staging platform_views_scroll_perf_ios__timeline_summary"
   triggers: "Mac_staging post_backdrop_filter_perf_ios__timeline_summary"
+  triggers: "Mac_staging run_release_test"
+  triggers: "Mac_staging service_extensions_test"
   triggers: "Mac_staging simple_animation_perf_ios"
   triggers: "Mac_staging smoke_catalina_hot_mode_dev_cycle_ios__benchmark"
   triggers: "Mac_staging smoke_catalina_start_up_ios"
+  triggers: "Mac_staging textfield_perf__timeline_summary"
+  triggers: "Mac_staging tiles_scroll_perf__timeline_summary"
   triggers: "Mac_staging tiles_scroll_perf_ios__timeline_summary"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"

--- a/config/lib/common.star
+++ b/config/lib/common.star
@@ -362,6 +362,14 @@ def _mac_builder(properties = {}, caches = None, category = "Mac", **kwargs):
         **kwargs
     )
 
+def _mac_android_builder(properties = {}, caches = None, category = "Mac_android", **kwargs):
+    return _common_builder(
+        os = "Mac",
+        properties = properties,
+        category = category,
+        **kwargs
+    )
+
 def _linux_builder(
         properties = {},
         caches = None,
@@ -390,6 +398,7 @@ def _windows_builder(
 
 _linux_try_builder, _linux_prod_builder = _linux_builder()
 _mac_try_builder, _mac_prod_builder = _mac_builder()
+_mac_android_try_builder, _mac_android_prod_builder = _mac_android_builder()
 _windows_try_builder, _windows_prod_builder = _windows_builder()
 
 common = struct(
@@ -404,6 +413,8 @@ common = struct(
     linux_prod_builder = _linux_prod_builder,
     mac_try_builder = _mac_try_builder,
     mac_prod_builder = _mac_prod_builder,
+    mac_android_try_builder = _mac_android_try_builder,
+    mac_android_prod_builder = _mac_android_prod_builder,
     windows_try_builder = _windows_try_builder,
     windows_prod_builder = _windows_prod_builder,
     try_builder = _try_builder,

--- a/config/lib/common.star
+++ b/config/lib/common.star
@@ -362,14 +362,6 @@ def _mac_builder(properties = {}, caches = None, category = "Mac", **kwargs):
         **kwargs
     )
 
-def _mac_android_builder(properties = {}, caches = None, category = "Mac_android", **kwargs):
-    return _common_builder(
-        os = "Mac",
-        properties = properties,
-        category = category,
-        **kwargs
-    )
-
 def _linux_builder(
         properties = {},
         caches = None,
@@ -398,7 +390,6 @@ def _windows_builder(
 
 _linux_try_builder, _linux_prod_builder = _linux_builder()
 _mac_try_builder, _mac_prod_builder = _mac_builder()
-_mac_android_try_builder, _mac_android_prod_builder = _mac_android_builder()
 _windows_try_builder, _windows_prod_builder = _windows_builder()
 
 common = struct(
@@ -413,8 +404,6 @@ common = struct(
     linux_prod_builder = _linux_prod_builder,
     mac_try_builder = _mac_try_builder,
     mac_prod_builder = _mac_prod_builder,
-    mac_android_try_builder = _mac_android_try_builder,
-    mac_android_prod_builder = _mac_android_prod_builder,
     windows_try_builder = _windows_try_builder,
     windows_prod_builder = _windows_prod_builder,
     try_builder = _try_builder,


### PR DESCRIPTION
This is to enable devicelab mac-android tests in staging env.

This PR also adds a new category `Mac_android` to distinguish from existing `Mac` category which is mainly for `mac-ios` tests.

Related issue: https://github.com/flutter/flutter/issues/74059