### PR TITLE
Add mac_model dimension for engine Mac builders to use Macmini8

### DIFF
--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -255,6 +255,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.windows_prod_builder(
@@ -374,6 +375,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         execution_timeout = timeout.MEDIUM_LONG,
         **platform_args["mac"]
     )
@@ -388,6 +390,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.mac_prod_builder(
@@ -398,6 +401,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.mac_prod_builder(
@@ -412,6 +416,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         execution_timeout = timeout.LONG,
         **platform_args["mac"]
     )
@@ -427,6 +432,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         execution_timeout = timeout.LONG,
         **platform_args["mac"]
     )
@@ -442,6 +448,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"mac_model": "Macmini8,1"},
         execution_timeout = timeout.LONG,
         **platform_args["mac"]
     )
@@ -531,6 +538,7 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
         recipe = "web_engine",
         repo = repos.ENGINE,
         list_view_name = list_view_name,
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["windows"]
     )
     common.linux_try_builder(
@@ -663,6 +671,7 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
             build_host = True,
             no_lto = True,
         ),
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.mac_try_builder(
@@ -675,6 +684,7 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
             build_android_vulkan = True,
             no_lto = True,
         ),
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.mac_try_builder(
@@ -686,6 +696,7 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
             build_android_aot = True,
             no_lto = True,
         ),
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.mac_try_builder(
@@ -700,6 +711,7 @@ def engine_try_config(platform_args, fuchsia_ctl_version):
             no_bitcode = True,
             no_lto = True,
         ),
+        dimensions = {"mac_model": "Macmini8,1"},
         **platform_args["mac"]
     )
     common.mac_try_builder(

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -16931,6 +16931,7 @@ buckets {
     builders {
       name: "Mac Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -16972,6 +16973,7 @@ buckets {
     builders {
       name: "Mac Android Debug Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17116,6 +17118,7 @@ buckets {
     builders {
       name: "Mac Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17207,6 +17210,7 @@ buckets {
     builders {
       name: "Mac Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17246,6 +17250,7 @@ buckets {
     builders {
       name: "Mac beta Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17287,6 +17292,7 @@ buckets {
     builders {
       name: "Mac beta Android Debug Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17353,6 +17359,7 @@ buckets {
     builders {
       name: "Mac beta Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17444,6 +17451,7 @@ buckets {
     builders {
       name: "Mac beta Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -17989,6 +17997,7 @@ buckets {
     builders {
       name: "Mac beta iOS Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -18033,6 +18042,7 @@ buckets {
     builders {
       name: "Mac beta iOS Engine Profile"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -18077,6 +18087,7 @@ buckets {
     builders {
       name: "Mac beta iOS Engine Release"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -18886,6 +18897,7 @@ buckets {
     builders {
       name: "Mac dev Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -18927,6 +18939,7 @@ buckets {
     builders {
       name: "Mac dev Android Debug Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -18993,6 +19006,7 @@ buckets {
     builders {
       name: "Mac dev Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -19084,6 +19098,7 @@ buckets {
     builders {
       name: "Mac dev Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -19629,6 +19644,7 @@ buckets {
     builders {
       name: "Mac dev iOS Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -19673,6 +19689,7 @@ buckets {
     builders {
       name: "Mac dev iOS Engine Profile"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -19717,6 +19734,7 @@ buckets {
     builders {
       name: "Mac dev iOS Engine Release"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -20582,6 +20600,7 @@ buckets {
     builders {
       name: "Mac iOS Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -20626,6 +20645,7 @@ buckets {
     builders {
       name: "Mac iOS Engine Profile"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -20670,6 +20690,7 @@ buckets {
     builders {
       name: "Mac iOS Engine Release"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21050,6 +21071,7 @@ buckets {
     builders {
       name: "Mac stable Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21091,6 +21113,7 @@ buckets {
     builders {
       name: "Mac stable Android Debug Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21157,6 +21180,7 @@ buckets {
     builders {
       name: "Mac stable Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21248,6 +21272,7 @@ buckets {
     builders {
       name: "Mac stable Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21793,6 +21818,7 @@ buckets {
     builders {
       name: "Mac stable iOS Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21837,6 +21863,7 @@ buckets {
     builders {
       name: "Mac stable iOS Engine Profile"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -21881,6 +21908,7 @@ buckets {
     builders {
       name: "Mac stable iOS Engine Release"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
       recipe {
@@ -39346,6 +39374,7 @@ buckets {
     builders {
       name: "Mac Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.try"
       recipe {
@@ -39387,6 +39416,7 @@ buckets {
     builders {
       name: "Mac Android Debug Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.try"
       recipe {
@@ -39456,6 +39486,7 @@ buckets {
     builders {
       name: "Mac Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.try"
       recipe {
@@ -40116,6 +40147,7 @@ buckets {
     builders {
       name: "Mac iOS Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.try"
       recipe {
@@ -40835,6 +40867,7 @@ buckets {
     builders {
       name: "Windows Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "mac_model:Macmini8,1"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.try"
       recipe {


### PR DESCRIPTION
This PR solves https://github.com/flutter/flutter/issues/74642, to avoid timeout of engine Mac builders.