### PR TITLE
Adjust devicelab linux and mac/android builder expiration_timeout

### DIFF
--- a/config/devicelab_config.star
+++ b/config/devicelab_config.star
@@ -352,7 +352,7 @@ def devicelab_prod_config(branch, version, ref):
             dimensions = {"device_os": "N"},
             # TODO(keyonghan): adjust the timeout when devicelab linux tasks are stable:
             # https://github.com/flutter/flutter/issues/72383.
-            expiration_timeout = timeout.LONG_EXPIRATION,
+            expiration_timeout = timeout.XL,
             execution_timeout = timeout.SHORT,
             caches = LINUX_DEFAULT_CACHES,
         )
@@ -455,7 +455,7 @@ def devicelab_prod_config(branch, version, ref):
             os = "Mac",
             category = "Mac_android",
             dimensions = {"device_os": "N"},
-            expiration_timeout = timeout.LONG_EXPIRATION,
+            expiration_timeout = timeout.XL,
             execution_timeout = timeout.SHORT,
             caches = MAC_ANDROID_DEFAULT_CACHES,
         )

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -572,7 +572,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -622,7 +622,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -672,7 +672,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -722,7 +722,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -772,7 +772,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -822,7 +822,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -872,7 +872,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -922,7 +922,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1456,7 +1456,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1506,7 +1506,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1556,7 +1556,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1606,7 +1606,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1656,7 +1656,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1706,7 +1706,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1756,7 +1756,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1806,7 +1806,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -1951,7 +1951,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2001,7 +2001,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2051,7 +2051,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2101,7 +2101,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2151,7 +2151,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2201,7 +2201,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2251,7 +2251,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2301,7 +2301,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2496,7 +2496,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2651,7 +2651,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2701,7 +2701,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2751,7 +2751,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2801,7 +2801,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2851,7 +2851,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2901,7 +2901,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -2951,7 +2951,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3001,7 +3001,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3051,7 +3051,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3101,7 +3101,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3151,7 +3151,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3201,7 +3201,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3251,7 +3251,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3349,7 +3349,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3399,7 +3399,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3779,7 +3779,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3829,7 +3829,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3879,7 +3879,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3929,7 +3929,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -3979,7 +3979,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4170,7 +4170,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4220,7 +4220,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4270,7 +4270,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4320,7 +4320,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4370,7 +4370,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4467,7 +4467,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4565,7 +4565,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -4951,7 +4951,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5240,7 +5240,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5290,7 +5290,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5340,7 +5340,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5390,7 +5390,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5440,7 +5440,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5490,7 +5490,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5540,7 +5540,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -5590,7 +5590,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6183,7 +6183,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6233,7 +6233,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6283,7 +6283,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6333,7 +6333,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6383,7 +6383,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6433,7 +6433,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6483,7 +6483,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6533,7 +6533,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6678,7 +6678,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6728,7 +6728,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6778,7 +6778,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6828,7 +6828,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6878,7 +6878,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6928,7 +6928,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -6978,7 +6978,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7028,7 +7028,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7223,7 +7223,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7378,7 +7378,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7428,7 +7428,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7478,7 +7478,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7528,7 +7528,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7578,7 +7578,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7628,7 +7628,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7678,7 +7678,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7728,7 +7728,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7778,7 +7778,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7828,7 +7828,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7878,7 +7878,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7928,7 +7928,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -7978,7 +7978,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8076,7 +8076,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8126,7 +8126,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8506,7 +8506,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8556,7 +8556,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8606,7 +8606,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8656,7 +8656,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8706,7 +8706,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8897,7 +8897,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8947,7 +8947,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -8997,7 +8997,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -9047,7 +9047,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -9097,7 +9097,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -9194,7 +9194,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -9292,7 +9292,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -9678,7 +9678,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -9922,7 +9922,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10077,7 +10077,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10127,7 +10127,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10177,7 +10177,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10227,7 +10227,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10277,7 +10277,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10327,7 +10327,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10377,7 +10377,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10427,7 +10427,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10477,7 +10477,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10527,7 +10527,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10577,7 +10577,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10627,7 +10627,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10677,7 +10677,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10775,7 +10775,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -10825,7 +10825,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11205,7 +11205,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11255,7 +11255,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11305,7 +11305,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11355,7 +11355,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11405,7 +11405,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11596,7 +11596,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11646,7 +11646,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11696,7 +11696,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11746,7 +11746,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11796,7 +11796,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -11893,7 +11893,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12391,7 +12391,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12441,7 +12441,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12491,7 +12491,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12541,7 +12541,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12591,7 +12591,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12641,7 +12641,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12691,7 +12691,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12741,7 +12741,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12886,7 +12886,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12936,7 +12936,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -12986,7 +12986,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13036,7 +13036,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13086,7 +13086,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13136,7 +13136,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13186,7 +13186,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13236,7 +13236,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13431,7 +13431,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13586,7 +13586,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13636,7 +13636,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13686,7 +13686,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13736,7 +13736,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13786,7 +13786,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13836,7 +13836,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13886,7 +13886,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13936,7 +13936,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -13986,7 +13986,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14036,7 +14036,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14086,7 +14086,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14136,7 +14136,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14186,7 +14186,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14284,7 +14284,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14334,7 +14334,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14714,7 +14714,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14764,7 +14764,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14814,7 +14814,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14864,7 +14864,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -14914,7 +14914,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15105,7 +15105,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15155,7 +15155,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15205,7 +15205,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15255,7 +15255,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15305,7 +15305,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15402,7 +15402,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15500,7 +15500,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -15886,7 +15886,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -16128,7 +16128,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -16514,7 +16514,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -22793,7 +22793,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -22842,7 +22842,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -22891,7 +22891,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -22940,7 +22940,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -22989,7 +22989,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23038,7 +23038,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23087,7 +23087,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23136,7 +23136,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23185,7 +23185,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23234,7 +23234,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23283,7 +23283,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23332,7 +23332,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23381,7 +23381,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23430,7 +23430,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23479,7 +23479,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23528,7 +23528,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23577,7 +23577,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23626,7 +23626,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23675,7 +23675,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23724,7 +23724,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23773,7 +23773,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23822,7 +23822,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23871,7 +23871,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23920,7 +23920,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -23969,7 +23969,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24018,7 +24018,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24067,7 +24067,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24116,7 +24116,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24165,7 +24165,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24214,7 +24214,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24263,7 +24263,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24312,7 +24312,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24361,7 +24361,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24410,7 +24410,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24459,7 +24459,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24508,7 +24508,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24557,7 +24557,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24606,7 +24606,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24655,7 +24655,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24704,7 +24704,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24753,7 +24753,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24802,7 +24802,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24851,7 +24851,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24900,7 +24900,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24949,7 +24949,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -24998,7 +24998,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25047,7 +25047,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25096,7 +25096,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25145,7 +25145,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25194,7 +25194,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25243,7 +25243,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25292,7 +25292,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25341,7 +25341,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25390,7 +25390,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25439,7 +25439,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25488,7 +25488,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25537,7 +25537,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25586,7 +25586,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25635,7 +25635,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25684,7 +25684,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25733,7 +25733,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25782,7 +25782,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25831,7 +25831,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25880,7 +25880,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25929,7 +25929,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -25978,7 +25978,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26027,7 +26027,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26076,7 +26076,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26125,7 +26125,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26174,7 +26174,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26223,7 +26223,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26272,7 +26272,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26321,7 +26321,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26370,7 +26370,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26419,7 +26419,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26468,7 +26468,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26517,7 +26517,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26566,7 +26566,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26615,7 +26615,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26664,7 +26664,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26713,7 +26713,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26762,7 +26762,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26811,7 +26811,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26860,7 +26860,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26909,7 +26909,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -26958,7 +26958,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27007,7 +27007,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27056,7 +27056,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27105,7 +27105,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27154,7 +27154,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27203,7 +27203,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27252,7 +27252,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27301,7 +27301,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27350,7 +27350,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27399,7 +27399,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27448,7 +27448,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27497,7 +27497,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27546,7 +27546,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27595,7 +27595,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27644,7 +27644,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27693,7 +27693,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27742,7 +27742,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27791,7 +27791,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27840,7 +27840,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27889,7 +27889,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27938,7 +27938,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -27987,7 +27987,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28036,7 +28036,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28085,7 +28085,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28134,7 +28134,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28183,7 +28183,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28232,7 +28232,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28281,7 +28281,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28330,7 +28330,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28379,7 +28379,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28428,7 +28428,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28477,7 +28477,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28526,7 +28526,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28575,7 +28575,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28624,7 +28624,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28673,7 +28673,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28722,7 +28722,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28771,7 +28771,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28820,7 +28820,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28869,7 +28869,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28918,7 +28918,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -28967,7 +28967,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29016,7 +29016,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29065,7 +29065,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29114,7 +29114,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29163,7 +29163,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29212,7 +29212,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29261,7 +29261,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29310,7 +29310,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29359,7 +29359,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29408,7 +29408,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29457,7 +29457,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29506,7 +29506,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29555,7 +29555,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29604,7 +29604,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29653,7 +29653,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29702,7 +29702,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29751,7 +29751,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29800,7 +29800,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29849,7 +29849,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29898,7 +29898,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29947,7 +29947,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -29996,7 +29996,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -30045,7 +30045,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -30094,7 +30094,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -30143,7 +30143,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"
@@ -30192,7 +30192,7 @@ buckets {
         properties_j: "upload_packages:true"
       }
       execution_timeout_secs: 1800
-      expiration_secs: 43200
+      expiration_secs: 10800
       caches {
         name: "android_sdk"
         path: "android"


### PR DESCRIPTION
It has been a while since we migrated devicelab Linux and Mac/Android tests to LUCI. 
Over the past month, the max queue time of these builders was ~2.7 hours.
This PR adjusts the expiration_timeout to be 3 hours instead of 12.

Related issue: https://github.com/flutter/flutter/issues/72383