### PR TITLE
Separate devicelab Linux host only tests from Linux-android tests

### DIFF
--- a/config/devicelab_config.star
+++ b/config/devicelab_config.star
@@ -357,6 +357,7 @@ def devicelab_prod_config(branch, version, ref):
             expiration_timeout = timeout.XL,
             execution_timeout = timeout.SHORT,
             caches = LINUX_DEFAULT_CACHES,
+            category = "Linux_android",
         )
 
     # Linux prod builders.

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -80,237 +80,237 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable analyzer_benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ab"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable android_defines_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "adt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable android_obfuscate_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "aot"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable android_stack_size_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "asst"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable android_view_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "avspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable animated_placeholder_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "appes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable animated_placeholder_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "app"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable backdrop_filter_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bfpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable basic_material_app_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bmaac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable color_filter_and_fade_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cfafp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable complex_layout_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable complex_layout_android__scroll_smoothness"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "class"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable complex_layout_scroll_perf__devtools_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clspd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable complex_layout_semantics_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clsp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable cubic_bezier_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable cubic_bezier_perf_sksl_warmup__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpsw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable cull_opacity_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "copes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable fast_scroll_heavy_gridview__memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fshgm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_engine_group_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fegp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__back_button_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgbbm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__image_cache_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgicm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__memory_nav"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgmn"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__start_up"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgsu"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__transition_perf_hybrid"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtph"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__transition_perf_with_semantics"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery_sksl_warmup__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery_sksl_warmup__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery_v2_chrome_run_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvcr"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_gallery_v2_web_compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvwc"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_test_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ftp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable frame_policy_delay_test_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fpdta"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable hot_mode_dev_cycle_linux__benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "hmdcl"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable image_list_jit_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "iljrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable image_list_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ilrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable large_image_changer_perf_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "licpa"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable linux_chrome_dev_mode"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "lcdm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable multi_widget_construction_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable multi_widget_construction_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable new_gallery__crane_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ngcp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable picture_cache_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pcpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable platform_views_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pvspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable routing_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "rt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable textfield_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "tpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_size__compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "wsct"
   }
   builders {
@@ -688,237 +688,237 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta analyzer_benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ab"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta android_defines_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "adt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta android_obfuscate_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "aot"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta android_stack_size_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "asst"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta android_view_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "avspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta animated_placeholder_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "appes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta animated_placeholder_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "app"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta backdrop_filter_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bfpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta basic_material_app_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bmaac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta color_filter_and_fade_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cfafp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta complex_layout_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta complex_layout_android__scroll_smoothness"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "class"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta complex_layout_scroll_perf__devtools_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clspd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta complex_layout_semantics_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clsp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta cubic_bezier_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta cubic_bezier_perf_sksl_warmup__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpsw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta cull_opacity_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "copes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta fast_scroll_heavy_gridview__memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fshgm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_engine_group_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fegp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__back_button_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgbbm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__image_cache_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgicm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__memory_nav"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgmn"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__start_up"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgsu"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__transition_perf_hybrid"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtph"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__transition_perf_with_semantics"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery_sksl_warmup__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery_sksl_warmup__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery_v2_chrome_run_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvcr"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_gallery_v2_web_compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvwc"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_test_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ftp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta frame_policy_delay_test_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fpdta"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta hot_mode_dev_cycle_linux__benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "hmdcl"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta image_list_jit_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "iljrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta image_list_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ilrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta large_image_changer_perf_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "licpa"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta linux_chrome_dev_mode"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "lcdm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta multi_widget_construction_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta multi_widget_construction_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta new_gallery__crane_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ngcp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta picture_cache_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pcpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta platform_views_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pvspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta routing_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "rt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta textfield_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "tpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_size__compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "wsct"
   }
   builders {
@@ -1296,237 +1296,237 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev analyzer_benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ab"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev android_defines_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "adt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev android_obfuscate_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "aot"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev android_stack_size_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "asst"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev android_view_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "avspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev animated_placeholder_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "appes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev animated_placeholder_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "app"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev backdrop_filter_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bfpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev basic_material_app_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bmaac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev color_filter_and_fade_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cfafp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev complex_layout_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev complex_layout_android__scroll_smoothness"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "class"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev complex_layout_scroll_perf__devtools_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clspd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev complex_layout_semantics_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clsp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev cubic_bezier_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev cubic_bezier_perf_sksl_warmup__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpsw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev cull_opacity_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "copes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev fast_scroll_heavy_gridview__memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fshgm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_engine_group_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fegp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__back_button_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgbbm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__image_cache_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgicm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__memory_nav"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgmn"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__start_up"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgsu"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__transition_perf_hybrid"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtph"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__transition_perf_with_semantics"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery_sksl_warmup__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery_sksl_warmup__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery_v2_chrome_run_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvcr"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_gallery_v2_web_compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvwc"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_test_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ftp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev frame_policy_delay_test_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fpdta"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev hot_mode_dev_cycle_linux__benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "hmdcl"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev image_list_jit_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "iljrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev image_list_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ilrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev large_image_changer_perf_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "licpa"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev linux_chrome_dev_mode"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "lcdm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev multi_widget_construction_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev multi_widget_construction_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev new_gallery__crane_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ngcp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev picture_cache_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pcpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev platform_views_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pvspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev routing_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "rt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev textfield_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "tpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_size__compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "wsct"
   }
   builders {
@@ -1904,237 +1904,237 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux analyzer_benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ab"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux android_defines_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "adt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux android_obfuscate_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "aot"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux android_stack_size_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "asst"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux android_view_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "avspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux animated_placeholder_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "appes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux animated_placeholder_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "app"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux backdrop_filter_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bfpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux basic_material_app_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "bmaac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux color_filter_and_fade_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cfafp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux complex_layout_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux complex_layout_android__scroll_smoothness"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "class"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux complex_layout_scroll_perf__devtools_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clspd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux complex_layout_semantics_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "clsp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux cubic_bezier_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux cubic_bezier_perf_sksl_warmup__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "cbpsw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux cull_opacity_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "copes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux fast_scroll_heavy_gridview__memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fshgm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_engine_group_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fegp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__back_button_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgbbm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__image_cache_memory"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgicm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__memory_nav"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgmn"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__start_up"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgsu"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__transition_perf_hybrid"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtph"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__transition_perf_with_semantics"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtpw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgtp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery_android__compile"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgac"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery_sksl_warmup__transition_perf_e2e"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery_sksl_warmup__transition_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgswt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery_v2_chrome_run_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvcr"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_gallery_v2_web_compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fgvwc"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_test_performance"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ftp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux frame_policy_delay_test_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "fpdta"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux hot_mode_dev_cycle_linux__benchmark"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "hmdcl"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux image_list_jit_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "iljrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux image_list_reported_duration"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ilrd"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux large_image_changer_perf_android"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "licpa"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux linux_chrome_dev_mode"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "lcdm"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux multi_widget_construction_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpe"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux multi_widget_construction_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "mwcpt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux new_gallery__crane_perf"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "ngcp"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux picture_cache_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pcpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux platform_views_scroll_perf__timeline_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "pvspt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux routing_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "rt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux textfield_perf__e2e_summary"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "tpes"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux web_size__compile_test"
-    category: "Linux"
+    category: "Linux_android"
     short_name: "wsct"
   }
   builders {


### PR DESCRIPTION
This group linux-android tests together in milo, to separate from host only tests.