### PR TITLE
Migrate smoke_catalina_start_up to LUCI

### DIFF
--- a/config/devicelab_config.star
+++ b/config/devicelab_config.star
@@ -427,6 +427,7 @@ def devicelab_prod_config(branch, version, ref):
         "platform_view__start_up",
         "run_release_test",
         "service_extensions_test",
+        "smoke_catalina_start_up",
         "textfield_perf__timeline_summary",
         "tiles_scroll_perf__timeline_summary",
     ]

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -25032,6 +25032,55 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_android beta smoke_catalina_start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "devicelab/devicelab_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"smoke_catalina_start_up\""
+        properties_j: "upload_metrics:false"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_android beta textfield_perf__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:N"
@@ -27286,6 +27335,55 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac_android dev smoke_catalina_start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"smoke_catalina_start_up\""
+        properties_j: "upload_metrics:false"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac_android dev textfield_perf__timeline_summary"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_os:N"
@@ -28628,6 +28726,55 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "task_name:\"service_extensions_test\""
+        properties_j: "upload_metrics:true"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android smoke_catalina_start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "devicelab/devicelab_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"smoke_catalina_start_up\""
         properties_j: "upload_metrics:true"
         properties_j: "upload_packages:true"
       }
@@ -30392,6 +30539,55 @@ buckets {
         properties_j: "goma_jobs:\"200\""
         properties_j: "mastername:\"client.flutter\""
         properties_j: "task_name:\"service_extensions_test\""
+        properties_j: "upload_metrics:false"
+        properties_j: "upload_packages:true"
+      }
+      execution_timeout_secs: 1800
+      expiration_secs: 10800
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac_android stable smoke_catalina_start_up"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_os:N"
+      dimensions: "os:Mac"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "devicelab/devicelab_drone_1_22_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "task_name:\"smoke_catalina_start_up\""
         properties_j: "upload_metrics:false"
         properties_j: "upload_packages:true"
       }

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -514,6 +514,11 @@ consoles {
     short_name: "set"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac_android stable smoke_catalina_start_up"
+    category: "Mac_android"
+    short_name: "scsu"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac_android stable textfield_perf__timeline_summary"
     category: "Mac_android"
     short_name: "tpts"
@@ -1120,6 +1125,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac_android beta service_extensions_test"
     category: "Mac_android"
     short_name: "set"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_android beta smoke_catalina_start_up"
+    category: "Mac_android"
+    short_name: "scsu"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac_android beta textfield_perf__timeline_summary"
@@ -1730,6 +1740,11 @@ consoles {
     short_name: "set"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac_android dev smoke_catalina_start_up"
+    category: "Mac_android"
+    short_name: "scsu"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac_android dev textfield_perf__timeline_summary"
     category: "Mac_android"
     short_name: "tpts"
@@ -2336,6 +2351,11 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac_android service_extensions_test"
     category: "Mac_android"
     short_name: "set"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac_android smoke_catalina_start_up"
+    category: "Mac_android"
+    short_name: "scsu"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac_android textfield_perf__timeline_summary"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -5522,6 +5522,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_android beta smoke_catalina_start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_android beta textfield_perf__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -6028,6 +6039,17 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac_android dev smoke_catalina_start_up"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac_android dev textfield_perf__timeline_summary"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -6326,6 +6348,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac_android service_extensions_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android smoke_catalina_start_up"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -6722,6 +6755,17 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac_android stable service_extensions_test"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac_android stable smoke_catalina_start_up"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -6968,6 +6968,20 @@ job {
   }
 }
 job {
+  id: "Mac_android beta smoke_catalina_start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android beta smoke_catalina_start_up"
+  }
+}
+job {
   id: "Mac_android beta textfield_perf__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
@@ -7612,6 +7626,20 @@ job {
   }
 }
 job {
+  id: "Mac_android dev smoke_catalina_start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android dev smoke_catalina_start_up"
+  }
+}
+job {
   id: "Mac_android dev textfield_perf__timeline_summary"
   acl_sets: "prod"
   triggering_policy {
@@ -8001,6 +8029,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_android service_extensions_test"
+  }
+}
+job {
+  id: "Mac_android smoke_catalina_start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 1
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android smoke_catalina_start_up"
   }
 }
 job {
@@ -8505,6 +8547,20 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac_android stable service_extensions_test"
+  }
+}
+job {
+  id: "Mac_android stable smoke_catalina_start_up"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac_android stable smoke_catalina_start_up"
   }
 }
 job {
@@ -10915,6 +10971,7 @@ trigger {
   triggers: "Mac_android beta platform_view__start_up"
   triggers: "Mac_android beta run_release_test"
   triggers: "Mac_android beta service_extensions_test"
+  triggers: "Mac_android beta smoke_catalina_start_up"
   triggers: "Mac_android beta textfield_perf__timeline_summary"
   triggers: "Mac_android beta tiles_scroll_perf__timeline_summary"
   triggers: "Windows beta build_aar_module_test"
@@ -11127,6 +11184,7 @@ trigger {
   triggers: "Mac_android dev platform_view__start_up"
   triggers: "Mac_android dev run_release_test"
   triggers: "Mac_android dev service_extensions_test"
+  triggers: "Mac_android dev smoke_catalina_start_up"
   triggers: "Mac_android dev textfield_perf__timeline_summary"
   triggers: "Mac_android dev tiles_scroll_perf__timeline_summary"
   triggers: "Windows dev build_aar_module_test"
@@ -11402,6 +11460,7 @@ trigger {
   triggers: "Mac_android platform_view__start_up"
   triggers: "Mac_android run_release_test"
   triggers: "Mac_android service_extensions_test"
+  triggers: "Mac_android smoke_catalina_start_up"
   triggers: "Mac_android textfield_perf__timeline_summary"
   triggers: "Mac_android tiles_scroll_perf__timeline_summary"
   triggers: "Windows build_aar_module_test"
@@ -11704,6 +11763,7 @@ trigger {
   triggers: "Mac_android stable platform_view__start_up"
   triggers: "Mac_android stable run_release_test"
   triggers: "Mac_android stable service_extensions_test"
+  triggers: "Mac_android stable smoke_catalina_start_up"
   triggers: "Mac_android stable textfield_perf__timeline_summary"
   triggers: "Mac_android stable tiles_scroll_perf__timeline_summary"
   triggers: "Windows stable build_aar_module_test"


### PR DESCRIPTION
This migrates the last catalina-android test: `smoke_catalina_start_up` to LUCI.

Related: https://github.com/flutter/flutter/issues/74059