### PR TITLE
Separate SDK Mac and Windows shards into separate builders - prod

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -532,6 +532,23 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
     )
 
     # Windows platform
+    common.builder_with_subshards(
+        name = "Windows%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "build_tests",
+            "subshards": ["1_3", "2_3", "3_3"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
+        },
+        caches = WIN_DEFAULT_CACHES,
+        os = WINDOWS_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
+    )
     common.windows_prod_builder(
         name = "Windows%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
@@ -546,6 +563,23 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         },
         caches = WIN_DEFAULT_CACHES,
         os = WINDOWS_OS,
+    )
+    common.builder_with_subshards(
+        name = "Windows%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "framework_tests",
+            "subshards": ["libraries", "misc", "widgets"],
+            "dependencies": [{"dependency": "goldctl"}],
+        },
+        caches = WIN_DEFAULT_CACHES,
+        os = WINDOWS_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
     )
     common.windows_prod_builder(
         name = "Windows%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
@@ -562,6 +596,23 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         caches = WIN_DEFAULT_CACHES,
         os = WINDOWS_OS,
     )
+    common.builder_with_subshards(
+        name = "Windows%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "tool_tests",
+            "subshards": ["general", "commands"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}],
+        },
+        caches = WIN_DEFAULT_CACHES,
+        os = WINDOWS_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
+    )
     common.windows_prod_builder(
         name = "Windows%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
@@ -576,6 +627,23 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         },
         caches = WIN_DEFAULT_CACHES,
         os = WINDOWS_OS,
+    )
+    common.builder_with_subshards(
+        name = "Windows%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "tool_integration_tests",
+            "subshards": ["1_3", "2_3", "3_3"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
+        },
+        caches = WIN_DEFAULT_CACHES,
+        os = WINDOWS_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
     )
     common.windows_prod_builder(
         name = "Windows%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
@@ -633,6 +701,27 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
     )
 
     # Mac builders
+    common.builder_with_subshards(
+        name = "Mac%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "build_tests",
+            "subshards": ["1_4", "2_4", "3_4", "4_4"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "gems"}, {"dependency": "goldctl"}],
+            "$flutter/osx_sdk": {
+                "sdk_version": XCODE_VERSION,
+            },
+        },
+        dimensions = {"device_type": "none"},
+        caches = MAC_NEWXCODE_CACHES,
+        os = MAC_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
+    )
     common.mac_prod_builder(
         name = "Mac%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
@@ -651,6 +740,27 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         dimensions = {"device_type": "none"},
         caches = MAC_NEWXCODE_CACHES,
         os = MAC_OS,
+    )
+    common.builder_with_subshards(
+        name = "Mac%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "framework_tests",
+            "subshards": ["libraries", "misc", "widgets"],
+            "dependencies": [{"dependency": "goldctl"}],
+            "$flutter/osx_sdk": {
+                "sdk_version": XCODE_VERSION,
+            },
+        },
+        dimensions = {"device_type": "none"},
+        caches = MAC_DEFAULT_CACHES,
+        os = MAC_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
     )
     common.mac_prod_builder(
         name = "Mac%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
@@ -671,6 +781,27 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         caches = MAC_DEFAULT_CACHES,
         os = MAC_OS,
     )
+    common.builder_with_subshards(
+        name = "Mac%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "tool_tests",
+            "subshards": ["general", "commands"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}],
+            "$flutter/osx_sdk": {
+                "sdk_version": XCODE_VERSION,
+            },
+        },
+        dimensions = {"device_type": "none"},
+        caches = MAC_DEFAULT_CACHES,
+        os = MAC_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
+    )
     common.mac_prod_builder(
         name = "Mac%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
         recipe = new_recipe_name,
@@ -689,6 +820,27 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         dimensions = {"device_type": "none"},
         caches = MAC_DEFAULT_CACHES,
         os = MAC_OS,
+    )
+    common.builder_with_subshards(
+        name = "Mac%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
+        recipe = drone_recipe_name,
+        console_view_name = console_view_name,
+        triggered_by = [trigger_name],
+        triggering_policy = triggering_policy,
+        priority = priority,
+        properties = {
+            "shard": "tool_integration_tests",
+            "subshards": ["1_3", "2_3", "3_3"],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "gems"}, {"dependency": "goldctl"}],
+            "$flutter/osx_sdk": {
+                "sdk_version": XCODE_VERSION,
+            },
+        },
+        dimensions = {"device_type": "none"},
+        caches = MAC_DEFAULT_CACHES,
+        os = MAC_OS,
+        bucket = "prod",
+        branch_name = "" if branch == "master" else " " + branch,
     )
     common.mac_prod_builder(
         name = "Mac%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -22267,6 +22267,238 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac beta build_tests_1_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta build_tests_2_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta build_tests_3_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta build_tests_4_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"4_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac beta customer_testing"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -22402,6 +22634,180 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -23212,6 +23618,180 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac beta tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac beta tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -23233,6 +23813,122 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac beta tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -23498,6 +24194,238 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"build_tests\""
         properties_j: "subshards:[\"1_4\",\"2_4\",\"3_4\",\"4_4\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac build_tests_1_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac build_tests_2_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac build_tests_3_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac build_tests_4_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"4_4\""
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -24070,6 +24998,238 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac dev build_tests_1_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev build_tests_2_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev build_tests_3_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev build_tests_4_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"4_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac dev customer_testing"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -24205,6 +25365,180 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -25015,6 +26349,180 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac dev tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac dev tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -25036,6 +26544,122 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac dev tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -25185,6 +26809,180 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -26358,6 +28156,238 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac stable build_tests_1_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable build_tests_2_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable build_tests_3_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable build_tests_4_4"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"4_4\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "new_osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac stable customer_testing"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -26493,6 +28523,180 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -27303,6 +29507,180 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac stable tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac stable tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -27324,6 +29702,122 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac stable tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -27510,6 +30004,180 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Mac tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Mac tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -27531,6 +30199,122 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "osx_sdk"
+        path: "osx_sdk"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      caches {
+        name: "xcode_binary"
+        path: "xcode_binary"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Mac tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
+      dimensions: "os:Mac-10.15"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -48382,6 +51166,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows beta build_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta build_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta build_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows beta customer_testing"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -48448,6 +51376,150 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -48909,6 +51981,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows beta tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows beta tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -48928,6 +52144,102 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows beta tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_27_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -49072,6 +52384,150 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"build_tests\""
         properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows build_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows build_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows build_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_3\""
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -49408,6 +52864,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows dev build_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev build_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev build_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows dev customer_testing"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -49474,6 +53074,150 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -49935,6 +53679,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows dev tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows dev tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -49954,6 +53842,102 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows dev tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -50050,6 +54034,150 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -50770,6 +54898,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows stable build_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable build_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable build_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"build_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows stable customer_testing"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -50836,6 +55108,150 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"framework_tests\""
         properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable framework_tests_libraries"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"libraries\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable framework_tests_misc"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"misc\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable framework_tests_widgets"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"framework_tests\""
+        properties_j: "subshard:\"widgets\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -51297,6 +55713,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows stable tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows stable tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -51316,6 +55876,102 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 29
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows stable tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone_1_26_0"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -51441,6 +56097,150 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
+      name: "Windows tool_integration_tests_1_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"1_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows tool_integration_tests_2_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"2_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows tool_integration_tests_3_3"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_integration_tests\""
+        properties_j: "subshard:\"3_3\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
       name: "Windows tool_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -51460,6 +56260,102 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_tests\""
         properties_j: "subshards:[\"general\",\"commands\"]"
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows tool_tests_commands"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"commands\""
+        properties_j: "upload_packages:true"
+      }
+      priority: 30
+      execution_timeout_secs: 3600
+      caches {
+        name: "android_sdk"
+        path: "android"
+      }
+      caches {
+        name: "chrome_and_driver"
+        path: "chrome"
+      }
+      caches {
+        name: "flutter_sdk"
+        path: "flutter sdk"
+      }
+      caches {
+        name: "openjdk"
+        path: "java"
+      }
+      caches {
+        name: "pub_cache"
+        path: ".pub-cache"
+      }
+      build_numbers: YES
+      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
+      task_template_canary_percentage {}
+    }
+    builders {
+      name: "Windows tool_tests_general"
+      swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "os:Windows-Server"
+      dimensions: "pool:luci.flutter.prod"
+      recipe {
+        name: "flutter/flutter_drone"
+        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
+        cipd_version: "refs/heads/master"
+        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
+        properties_j: "$kitchen:{\"emulate_gce\":true}"
+        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
+        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
+        properties_j: "clobber:false"
+        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
+        properties_j: "gold_tryjob:false"
+        properties_j: "goma_jobs:\"200\""
+        properties_j: "mastername:\"client.flutter\""
+        properties_j: "shard:\"tool_tests\""
+        properties_j: "subshard:\"general\""
         properties_j: "upload_packages:true"
       }
       priority: 30

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -4514,9 +4514,39 @@ consoles {
     short_name: "fltplgns"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable build_tests_1_3"
+    category: "Windows"
+    short_name: "bt13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable build_tests_2_3"
+    category: "Windows"
+    short_name: "bt23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable build_tests_3_3"
+    category: "Windows"
+    short_name: "bt33"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows stable build_tests"
     category: "Windows"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable framework_tests_libraries"
+    category: "Windows"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable framework_tests_misc"
+    category: "Windows"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable framework_tests_widgets"
+    category: "Windows"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows stable framework_tests"
@@ -4524,9 +4554,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable tool_tests_general"
+    category: "Windows"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable tool_tests_commands"
+    category: "Windows"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows stable tool_tests"
     category: "Windows"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests_1_3"
+    category: "Windows"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests_2_3"
+    category: "Windows"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests_3_3"
+    category: "Windows"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests"
@@ -4544,9 +4599,44 @@ consoles {
     short_name: "cst_test"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable build_tests_1_4"
+    category: "Mac"
+    short_name: "bt14"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable build_tests_2_4"
+    category: "Mac"
+    short_name: "bt24"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable build_tests_3_4"
+    category: "Mac"
+    short_name: "bt34"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable build_tests_4_4"
+    category: "Mac"
+    short_name: "bt44"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac stable build_tests"
     category: "Mac"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable framework_tests_libraries"
+    category: "Mac"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable framework_tests_misc"
+    category: "Mac"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable framework_tests_widgets"
+    category: "Mac"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable framework_tests"
@@ -4554,9 +4644,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable tool_tests_general"
+    category: "Mac"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable tool_tests_commands"
+    category: "Mac"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests_1_3"
+    category: "Mac"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests_2_3"
+    category: "Mac"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests_3_3"
+    category: "Mac"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests"
@@ -4767,9 +4882,39 @@ consoles {
     short_name: "fltplgns"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta build_tests_1_3"
+    category: "Windows"
+    short_name: "bt13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta build_tests_2_3"
+    category: "Windows"
+    short_name: "bt23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta build_tests_3_3"
+    category: "Windows"
+    short_name: "bt33"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows beta build_tests"
     category: "Windows"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta framework_tests_libraries"
+    category: "Windows"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta framework_tests_misc"
+    category: "Windows"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta framework_tests_widgets"
+    category: "Windows"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows beta framework_tests"
@@ -4777,9 +4922,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta tool_tests_general"
+    category: "Windows"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta tool_tests_commands"
+    category: "Windows"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows beta tool_tests"
     category: "Windows"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests_1_3"
+    category: "Windows"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests_2_3"
+    category: "Windows"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests_3_3"
+    category: "Windows"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests"
@@ -4797,9 +4967,44 @@ consoles {
     short_name: "cst_test"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta build_tests_1_4"
+    category: "Mac"
+    short_name: "bt14"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta build_tests_2_4"
+    category: "Mac"
+    short_name: "bt24"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta build_tests_3_4"
+    category: "Mac"
+    short_name: "bt34"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta build_tests_4_4"
+    category: "Mac"
+    short_name: "bt44"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac beta build_tests"
     category: "Mac"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta framework_tests_libraries"
+    category: "Mac"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta framework_tests_misc"
+    category: "Mac"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta framework_tests_widgets"
+    category: "Mac"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta framework_tests"
@@ -4807,9 +5012,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta tool_tests_general"
+    category: "Mac"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta tool_tests_commands"
+    category: "Mac"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests_1_3"
+    category: "Mac"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests_2_3"
+    category: "Mac"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests_3_3"
+    category: "Mac"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests"
@@ -5020,9 +5250,39 @@ consoles {
     short_name: "fltplgns"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev build_tests_1_3"
+    category: "Windows"
+    short_name: "bt13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev build_tests_2_3"
+    category: "Windows"
+    short_name: "bt23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev build_tests_3_3"
+    category: "Windows"
+    short_name: "bt33"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows dev build_tests"
     category: "Windows"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev framework_tests_libraries"
+    category: "Windows"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev framework_tests_misc"
+    category: "Windows"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev framework_tests_widgets"
+    category: "Windows"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows dev framework_tests"
@@ -5030,9 +5290,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev tool_tests_general"
+    category: "Windows"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev tool_tests_commands"
+    category: "Windows"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows dev tool_tests"
     category: "Windows"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests_1_3"
+    category: "Windows"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests_2_3"
+    category: "Windows"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests_3_3"
+    category: "Windows"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests"
@@ -5050,9 +5335,44 @@ consoles {
     short_name: "cst_test"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev build_tests_1_4"
+    category: "Mac"
+    short_name: "bt14"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev build_tests_2_4"
+    category: "Mac"
+    short_name: "bt24"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev build_tests_3_4"
+    category: "Mac"
+    short_name: "bt34"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev build_tests_4_4"
+    category: "Mac"
+    short_name: "bt44"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac dev build_tests"
     category: "Mac"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev framework_tests_libraries"
+    category: "Mac"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev framework_tests_misc"
+    category: "Mac"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev framework_tests_widgets"
+    category: "Mac"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev framework_tests"
@@ -5060,9 +5380,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev tool_tests_general"
+    category: "Mac"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev tool_tests_commands"
+    category: "Mac"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests_1_3"
+    category: "Mac"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests_2_3"
+    category: "Mac"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests_3_3"
+    category: "Mac"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests"
@@ -5268,9 +5613,39 @@ consoles {
     short_name: "fltplgns"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows build_tests_1_3"
+    category: "Windows"
+    short_name: "bt13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows build_tests_2_3"
+    category: "Windows"
+    short_name: "bt23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows build_tests_3_3"
+    category: "Windows"
+    short_name: "bt33"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows build_tests"
     category: "Windows"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows framework_tests_libraries"
+    category: "Windows"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows framework_tests_misc"
+    category: "Windows"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows framework_tests_widgets"
+    category: "Windows"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows framework_tests"
@@ -5278,9 +5653,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Windows tool_tests_general"
+    category: "Windows"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows tool_tests_commands"
+    category: "Windows"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Windows tool_tests"
     category: "Windows"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests_1_3"
+    category: "Windows"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests_2_3"
+    category: "Windows"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests_3_3"
+    category: "Windows"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests"
@@ -5298,9 +5698,44 @@ consoles {
     short_name: "cst_test"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac build_tests_1_4"
+    category: "Mac"
+    short_name: "bt14"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac build_tests_2_4"
+    category: "Mac"
+    short_name: "bt24"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac build_tests_3_4"
+    category: "Mac"
+    short_name: "bt34"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac build_tests_4_4"
+    category: "Mac"
+    short_name: "bt44"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac build_tests"
     category: "Mac"
     short_name: "bld_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac framework_tests_libraries"
+    category: "Mac"
+    short_name: "ftl"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac framework_tests_misc"
+    category: "Mac"
+    short_name: "ftm"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac framework_tests_widgets"
+    category: "Mac"
+    short_name: "ftw"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac framework_tests"
@@ -5308,9 +5743,34 @@ consoles {
     short_name: "frwk_tests"
   }
   builders {
+    name: "buildbucket/luci.flutter.prod/Mac tool_tests_general"
+    category: "Mac"
+    short_name: "ttg"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac tool_tests_commands"
+    category: "Mac"
+    short_name: "ttc"
+  }
+  builders {
     name: "buildbucket/luci.flutter.prod/Mac tool_tests"
     category: "Mac"
     short_name: "tool_tests"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests_1_3"
+    category: "Mac"
+    short_name: "tit13"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests_2_3"
+    category: "Mac"
+    short_name: "tit23"
+  }
+  builders {
+    name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests_3_3"
+    category: "Mac"
+    short_name: "tit33"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -4972,6 +4972,50 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac beta build_tests_1_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta build_tests_2_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta build_tests_3_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta build_tests_4_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac beta customer_testing"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4995,6 +5039,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac beta framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5159,7 +5236,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac beta tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac beta tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac beta tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5215,6 +5347,50 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac build_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac build_tests_1_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac build_tests_2_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac build_tests_3_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac build_tests_4_4"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5324,6 +5500,50 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac dev build_tests_1_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev build_tests_2_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev build_tests_3_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev build_tests_4_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac dev customer_testing"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5347,6 +5567,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac dev framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5511,7 +5764,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac dev tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac dev tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac dev tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5545,6 +5853,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5775,6 +6116,50 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac stable build_tests_1_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable build_tests_2_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable build_tests_3_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable build_tests_4_4"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac stable customer_testing"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5798,6 +6183,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac stable framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5962,7 +6380,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac stable tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac stable tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac stable tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -6006,7 +6479,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Mac tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Mac tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Mac tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10351,6 +10879,39 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows beta build_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta build_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta build_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows beta customer_testing"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -10363,6 +10924,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows beta framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10472,7 +11066,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows beta tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows beta tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows beta tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10506,6 +11155,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows build_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows build_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows build_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows build_tests_3_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10582,6 +11264,39 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows dev build_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev build_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev build_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows dev customer_testing"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -10594,6 +11309,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows dev framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10703,7 +11451,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows dev tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows dev tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows dev tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10726,6 +11529,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10890,6 +11726,39 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows stable build_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable build_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable build_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows stable customer_testing"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -10902,6 +11771,39 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows stable framework_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable framework_tests_libraries"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable framework_tests_misc"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable framework_tests_widgets"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -11011,7 +11913,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows stable tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows stable tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows stable tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -11044,7 +12001,62 @@ notifiers {
   }
   builders {
     bucket: "prod"
+    name: "Windows tool_integration_tests_1_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows tool_integration_tests_2_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows tool_integration_tests_3_3"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
     name: "Windows tool_tests"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows tool_tests_commands"
+    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
+  }
+}
+notifiers {
+  notifications {
+    on_new_failure: true
+    notify_blamelist {}
+  }
+  builders {
+    bucket: "prod"
+    name: "Windows tool_tests_general"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -6277,6 +6277,62 @@ job {
   }
 }
 job {
+  id: "Mac beta build_tests_1_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta build_tests_1_4"
+  }
+}
+job {
+  id: "Mac beta build_tests_2_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta build_tests_2_4"
+  }
+}
+job {
+  id: "Mac beta build_tests_3_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta build_tests_3_4"
+  }
+}
+job {
+  id: "Mac beta build_tests_4_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta build_tests_4_4"
+  }
+}
+job {
   id: "Mac beta customer_testing"
   acl_sets: "prod"
   triggering_policy {
@@ -6316,6 +6372,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac beta framework_tests"
+  }
+}
+job {
+  id: "Mac beta framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta framework_tests_libraries"
+  }
+}
+job {
+  id: "Mac beta framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta framework_tests_misc"
+  }
+}
+job {
+  id: "Mac beta framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta framework_tests_widgets"
   }
 }
 job {
@@ -6512,6 +6610,48 @@ job {
   }
 }
 job {
+  id: "Mac beta tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Mac beta tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Mac beta tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Mac beta tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -6523,6 +6663,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac beta tool_tests"
+  }
+}
+job {
+  id: "Mac beta tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta tool_tests_commands"
+  }
+}
+job {
+  id: "Mac beta tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac beta tool_tests_general"
   }
 }
 job {
@@ -6593,6 +6761,62 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac build_tests"
+  }
+}
+job {
+  id: "Mac build_tests_1_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac build_tests_1_4"
+  }
+}
+job {
+  id: "Mac build_tests_2_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac build_tests_2_4"
+  }
+}
+job {
+  id: "Mac build_tests_3_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac build_tests_3_4"
+  }
+}
+job {
+  id: "Mac build_tests_4_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac build_tests_4_4"
   }
 }
 job {
@@ -6718,6 +6942,62 @@ job {
   }
 }
 job {
+  id: "Mac dev build_tests_1_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev build_tests_1_4"
+  }
+}
+job {
+  id: "Mac dev build_tests_2_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev build_tests_2_4"
+  }
+}
+job {
+  id: "Mac dev build_tests_3_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev build_tests_3_4"
+  }
+}
+job {
+  id: "Mac dev build_tests_4_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev build_tests_4_4"
+  }
+}
+job {
   id: "Mac dev customer_testing"
   acl_sets: "prod"
   triggering_policy {
@@ -6757,6 +7037,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev framework_tests"
+  }
+}
+job {
+  id: "Mac dev framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev framework_tests_libraries"
+  }
+}
+job {
+  id: "Mac dev framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev framework_tests_misc"
+  }
+}
+job {
+  id: "Mac dev framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev framework_tests_widgets"
   }
 }
 job {
@@ -6953,6 +7275,48 @@ job {
   }
 }
 job {
+  id: "Mac dev tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Mac dev tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Mac dev tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Mac dev tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -6964,6 +7328,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev tool_tests"
+  }
+}
+job {
+  id: "Mac dev tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev tool_tests_commands"
+  }
+}
+job {
+  id: "Mac dev tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac dev tool_tests_general"
   }
 }
 job {
@@ -7006,6 +7398,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac framework_tests"
+  }
+}
+job {
+  id: "Mac framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac framework_tests_libraries"
+  }
+}
+job {
+  id: "Mac framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac framework_tests_misc"
+  }
+}
+job {
+  id: "Mac framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac framework_tests_widgets"
   }
 }
 job {
@@ -7285,6 +7719,62 @@ job {
   }
 }
 job {
+  id: "Mac stable build_tests_1_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable build_tests_1_4"
+  }
+}
+job {
+  id: "Mac stable build_tests_2_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable build_tests_2_4"
+  }
+}
+job {
+  id: "Mac stable build_tests_3_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable build_tests_3_4"
+  }
+}
+job {
+  id: "Mac stable build_tests_4_4"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable build_tests_4_4"
+  }
+}
+job {
   id: "Mac stable customer_testing"
   acl_sets: "prod"
   triggering_policy {
@@ -7324,6 +7814,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac stable framework_tests"
+  }
+}
+job {
+  id: "Mac stable framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable framework_tests_libraries"
+  }
+}
+job {
+  id: "Mac stable framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable framework_tests_misc"
+  }
+}
+job {
+  id: "Mac stable framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable framework_tests_widgets"
   }
 }
 job {
@@ -7520,6 +8052,48 @@ job {
   }
 }
 job {
+  id: "Mac stable tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Mac stable tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Mac stable tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Mac stable tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -7531,6 +8105,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac stable tool_tests"
+  }
+}
+job {
+  id: "Mac stable tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable tool_tests_commands"
+  }
+}
+job {
+  id: "Mac stable tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac stable tool_tests_general"
   }
 }
 job {
@@ -7576,6 +8178,48 @@ job {
   }
 }
 job {
+  id: "Mac tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Mac tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Mac tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Mac tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -7587,6 +8231,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac tool_tests"
+  }
+}
+job {
+  id: "Mac tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac tool_tests_commands"
+  }
+}
+job {
+  id: "Mac tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Mac tool_tests_general"
   }
 }
 job {
@@ -13100,6 +13772,48 @@ job {
   }
 }
 job {
+  id: "Windows beta build_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta build_tests_1_3"
+  }
+}
+job {
+  id: "Windows beta build_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta build_tests_2_3"
+  }
+}
+job {
+  id: "Windows beta build_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta build_tests_3_3"
+  }
+}
+job {
   id: "Windows beta customer_testing"
   acl_sets: "prod"
   triggering_policy {
@@ -13125,6 +13839,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows beta framework_tests"
+  }
+}
+job {
+  id: "Windows beta framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta framework_tests_libraries"
+  }
+}
+job {
+  id: "Windows beta framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta framework_tests_misc"
+  }
+}
+job {
+  id: "Windows beta framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta framework_tests_widgets"
   }
 }
 job {
@@ -13254,6 +14010,48 @@ job {
   }
 }
 job {
+  id: "Windows beta tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Windows beta tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Windows beta tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Windows beta tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -13265,6 +14063,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows beta tool_tests"
+  }
+}
+job {
+  id: "Windows beta tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta tool_tests_commands"
+  }
+}
+job {
+  id: "Windows beta tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows beta tool_tests_general"
   }
 }
 job {
@@ -13307,6 +14133,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows build_tests"
+  }
+}
+job {
+  id: "Windows build_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows build_tests_1_3"
+  }
+}
+job {
+  id: "Windows build_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows build_tests_2_3"
+  }
+}
+job {
+  id: "Windows build_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows build_tests_3_3"
   }
 }
 job {
@@ -13391,6 +14259,48 @@ job {
   }
 }
 job {
+  id: "Windows dev build_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev build_tests_1_3"
+  }
+}
+job {
+  id: "Windows dev build_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev build_tests_2_3"
+  }
+}
+job {
+  id: "Windows dev build_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev build_tests_3_3"
+  }
+}
+job {
   id: "Windows dev customer_testing"
   acl_sets: "prod"
   triggering_policy {
@@ -13416,6 +14326,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows dev framework_tests"
+  }
+}
+job {
+  id: "Windows dev framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev framework_tests_libraries"
+  }
+}
+job {
+  id: "Windows dev framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev framework_tests_misc"
+  }
+}
+job {
+  id: "Windows dev framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev framework_tests_widgets"
   }
 }
 job {
@@ -13545,6 +14497,48 @@ job {
   }
 }
 job {
+  id: "Windows dev tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Windows dev tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Windows dev tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Windows dev tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -13556,6 +14550,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows dev tool_tests"
+  }
+}
+job {
+  id: "Windows dev tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev tool_tests_commands"
+  }
+}
+job {
+  id: "Windows dev tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows dev tool_tests_general"
   }
 }
 job {
@@ -13584,6 +14606,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows framework_tests"
+  }
+}
+job {
+  id: "Windows framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows framework_tests_libraries"
+  }
+}
+job {
+  id: "Windows framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows framework_tests_misc"
+  }
+}
+job {
+  id: "Windows framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows framework_tests_widgets"
   }
 }
 job {
@@ -13780,6 +14844,48 @@ job {
   }
 }
 job {
+  id: "Windows stable build_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable build_tests_1_3"
+  }
+}
+job {
+  id: "Windows stable build_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable build_tests_2_3"
+  }
+}
+job {
+  id: "Windows stable build_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable build_tests_3_3"
+  }
+}
+job {
   id: "Windows stable customer_testing"
   acl_sets: "prod"
   triggering_policy {
@@ -13805,6 +14911,48 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows stable framework_tests"
+  }
+}
+job {
+  id: "Windows stable framework_tests_libraries"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable framework_tests_libraries"
+  }
+}
+job {
+  id: "Windows stable framework_tests_misc"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable framework_tests_misc"
+  }
+}
+job {
+  id: "Windows stable framework_tests_widgets"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable framework_tests_widgets"
   }
 }
 job {
@@ -13934,6 +15082,48 @@ job {
   }
 }
 job {
+  id: "Windows stable tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Windows stable tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Windows stable tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Windows stable tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -13945,6 +15135,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows stable tool_tests"
+  }
+}
+job {
+  id: "Windows stable tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable tool_tests_commands"
+  }
+}
+job {
+  id: "Windows stable tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 1
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows stable tool_tests_general"
   }
 }
 job {
@@ -13976,6 +15194,48 @@ job {
   }
 }
 job {
+  id: "Windows tool_integration_tests_1_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows tool_integration_tests_1_3"
+  }
+}
+job {
+  id: "Windows tool_integration_tests_2_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows tool_integration_tests_2_3"
+  }
+}
+job {
+  id: "Windows tool_integration_tests_3_3"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows tool_integration_tests_3_3"
+  }
+}
+job {
   id: "Windows tool_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -13987,6 +15247,34 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows tool_tests"
+  }
+}
+job {
+  id: "Windows tool_tests_commands"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows tool_tests_commands"
+  }
+}
+job {
+  id: "Windows tool_tests_general"
+  acl_sets: "prod"
+  triggering_policy {
+    kind: GREEDY_BATCHING
+    max_concurrent_invocations: 3
+    max_batch_size: 3
+  }
+  buildbucket {
+    server: "cr-buildbucket.appspot.com"
+    bucket: "luci.flutter.prod"
+    builder: "Windows tool_tests_general"
   }
 }
 job {
@@ -14356,16 +15644,39 @@ trigger {
   triggers: "Linux beta web_tests_7_last"
   triggers: "Linux beta web_tool_tests"
   triggers: "Mac beta build_tests"
+  triggers: "Mac beta build_tests_1_4"
+  triggers: "Mac beta build_tests_2_4"
+  triggers: "Mac beta build_tests_3_4"
+  triggers: "Mac beta build_tests_4_4"
   triggers: "Mac beta customer_testing"
   triggers: "Mac beta framework_tests"
+  triggers: "Mac beta framework_tests_libraries"
+  triggers: "Mac beta framework_tests_misc"
+  triggers: "Mac beta framework_tests_widgets"
   triggers: "Mac beta tool_integration_tests"
+  triggers: "Mac beta tool_integration_tests_1_3"
+  triggers: "Mac beta tool_integration_tests_2_3"
+  triggers: "Mac beta tool_integration_tests_3_3"
   triggers: "Mac beta tool_tests"
+  triggers: "Mac beta tool_tests_commands"
+  triggers: "Mac beta tool_tests_general"
   triggers: "Mac beta web_tool_tests"
   triggers: "Windows beta build_tests"
+  triggers: "Windows beta build_tests_1_3"
+  triggers: "Windows beta build_tests_2_3"
+  triggers: "Windows beta build_tests_3_3"
   triggers: "Windows beta customer_testing"
   triggers: "Windows beta framework_tests"
+  triggers: "Windows beta framework_tests_libraries"
+  triggers: "Windows beta framework_tests_misc"
+  triggers: "Windows beta framework_tests_widgets"
   triggers: "Windows beta tool_integration_tests"
+  triggers: "Windows beta tool_integration_tests_1_3"
+  triggers: "Windows beta tool_integration_tests_2_3"
+  triggers: "Windows beta tool_integration_tests_3_3"
   triggers: "Windows beta tool_tests"
+  triggers: "Windows beta tool_tests_commands"
+  triggers: "Windows beta tool_tests_general"
   triggers: "Windows beta web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
@@ -14627,16 +15938,39 @@ trigger {
   triggers: "Linux dev web_tests_7_last"
   triggers: "Linux dev web_tool_tests"
   triggers: "Mac dev build_tests"
+  triggers: "Mac dev build_tests_1_4"
+  triggers: "Mac dev build_tests_2_4"
+  triggers: "Mac dev build_tests_3_4"
+  triggers: "Mac dev build_tests_4_4"
   triggers: "Mac dev customer_testing"
   triggers: "Mac dev framework_tests"
+  triggers: "Mac dev framework_tests_libraries"
+  triggers: "Mac dev framework_tests_misc"
+  triggers: "Mac dev framework_tests_widgets"
   triggers: "Mac dev tool_integration_tests"
+  triggers: "Mac dev tool_integration_tests_1_3"
+  triggers: "Mac dev tool_integration_tests_2_3"
+  triggers: "Mac dev tool_integration_tests_3_3"
   triggers: "Mac dev tool_tests"
+  triggers: "Mac dev tool_tests_commands"
+  triggers: "Mac dev tool_tests_general"
   triggers: "Mac dev web_tool_tests"
   triggers: "Windows dev build_tests"
+  triggers: "Windows dev build_tests_1_3"
+  triggers: "Windows dev build_tests_2_3"
+  triggers: "Windows dev build_tests_3_3"
   triggers: "Windows dev customer_testing"
   triggers: "Windows dev framework_tests"
+  triggers: "Windows dev framework_tests_libraries"
+  triggers: "Windows dev framework_tests_misc"
+  triggers: "Windows dev framework_tests_widgets"
   triggers: "Windows dev tool_integration_tests"
+  triggers: "Windows dev tool_integration_tests_1_3"
+  triggers: "Windows dev tool_integration_tests_2_3"
+  triggers: "Windows dev tool_integration_tests_3_3"
   triggers: "Windows dev tool_tests"
+  triggers: "Windows dev tool_tests_commands"
+  triggers: "Windows dev tool_tests_general"
   triggers: "Windows dev web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
@@ -15068,16 +16402,39 @@ trigger {
   triggers: "Linux web_tests_7_last"
   triggers: "Linux web_tool_tests"
   triggers: "Mac build_tests"
+  triggers: "Mac build_tests_1_4"
+  triggers: "Mac build_tests_2_4"
+  triggers: "Mac build_tests_3_4"
+  triggers: "Mac build_tests_4_4"
   triggers: "Mac customer_testing"
   triggers: "Mac framework_tests"
+  triggers: "Mac framework_tests_libraries"
+  triggers: "Mac framework_tests_misc"
+  triggers: "Mac framework_tests_widgets"
   triggers: "Mac tool_integration_tests"
+  triggers: "Mac tool_integration_tests_1_3"
+  triggers: "Mac tool_integration_tests_2_3"
+  triggers: "Mac tool_integration_tests_3_3"
   triggers: "Mac tool_tests"
+  triggers: "Mac tool_tests_commands"
+  triggers: "Mac tool_tests_general"
   triggers: "Mac web_tool_tests"
   triggers: "Windows build_tests"
+  triggers: "Windows build_tests_1_3"
+  triggers: "Windows build_tests_2_3"
+  triggers: "Windows build_tests_3_3"
   triggers: "Windows customer_testing"
   triggers: "Windows framework_tests"
+  triggers: "Windows framework_tests_libraries"
+  triggers: "Windows framework_tests_misc"
+  triggers: "Windows framework_tests_widgets"
   triggers: "Windows tool_integration_tests"
+  triggers: "Windows tool_integration_tests_1_3"
+  triggers: "Windows tool_integration_tests_2_3"
+  triggers: "Windows tool_integration_tests_3_3"
   triggers: "Windows tool_tests"
+  triggers: "Windows tool_tests_commands"
+  triggers: "Windows tool_tests_general"
   triggers: "Windows web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
@@ -15346,16 +16703,39 @@ trigger {
   triggers: "Linux stable web_tests_7_last"
   triggers: "Linux stable web_tool_tests"
   triggers: "Mac stable build_tests"
+  triggers: "Mac stable build_tests_1_4"
+  triggers: "Mac stable build_tests_2_4"
+  triggers: "Mac stable build_tests_3_4"
+  triggers: "Mac stable build_tests_4_4"
   triggers: "Mac stable customer_testing"
   triggers: "Mac stable framework_tests"
+  triggers: "Mac stable framework_tests_libraries"
+  triggers: "Mac stable framework_tests_misc"
+  triggers: "Mac stable framework_tests_widgets"
   triggers: "Mac stable tool_integration_tests"
+  triggers: "Mac stable tool_integration_tests_1_3"
+  triggers: "Mac stable tool_integration_tests_2_3"
+  triggers: "Mac stable tool_integration_tests_3_3"
   triggers: "Mac stable tool_tests"
+  triggers: "Mac stable tool_tests_commands"
+  triggers: "Mac stable tool_tests_general"
   triggers: "Mac stable web_tool_tests"
   triggers: "Windows stable build_tests"
+  triggers: "Windows stable build_tests_1_3"
+  triggers: "Windows stable build_tests_2_3"
+  triggers: "Windows stable build_tests_3_3"
   triggers: "Windows stable customer_testing"
   triggers: "Windows stable framework_tests"
+  triggers: "Windows stable framework_tests_libraries"
+  triggers: "Windows stable framework_tests_misc"
+  triggers: "Windows stable framework_tests_widgets"
   triggers: "Windows stable tool_integration_tests"
+  triggers: "Windows stable tool_integration_tests_1_3"
+  triggers: "Windows stable tool_integration_tests_2_3"
+  triggers: "Windows stable tool_integration_tests_3_3"
   triggers: "Windows stable tool_tests"
+  triggers: "Windows stable tool_tests_commands"
+  triggers: "Windows stable tool_tests_general"
   triggers: "Windows stable web_tool_tests"
   gitiles {
     repo: "https://chromium.googlesource.com/external/github.com/flutter/flutter"

--- a/config/lib/common.star
+++ b/config/lib/common.star
@@ -451,6 +451,20 @@ def _builder_with_subshards(
                 os = os,
                 **kwargs
             )
+        elif bucket == "prod" and os.startswith("Mac"):
+            _mac_prod_builder(
+                name = "Mac%s %s|%s" % (branch_name, buildername, _short_name(buildername)),
+                properties = properties,
+                os = os,
+                **kwargs
+            )
+        elif bucket == "prod" and os.startswith("Windows"):
+            _windows_prod_builder(
+                name = "Windows%s %s|%s" % (branch_name, buildername, _short_name(buildername)),
+                properties = properties,
+                os = os,
+                **kwargs
+            )
 
 common = struct(
     builder = _builder,


### PR DESCRIPTION
This creates separate builder configs for each subshard (Mac and Windows prod ones).

Related: flutter/flutter#77947