### PR TITLE
Remove old consolidated shard builders

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -460,21 +460,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.windows_prod_builder(
-        name = "Windows%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "build_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
-    )
     common.builder_with_subshards(
         name = "Windows%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -491,21 +476,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = WINDOWS_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.windows_prod_builder(
-        name = "Windows%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "framework_tests",
-            "subshards": ["libraries", "misc", "widgets"],
-            "dependencies": [{"dependency": "goldctl"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
     )
     common.builder_with_subshards(
         name = "Windows%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
@@ -524,21 +494,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.windows_prod_builder(
-        name = "Windows%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "tool_tests",
-            "subshards": ["general", "commands"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
-    )
     common.builder_with_subshards(
         name = "Windows%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -555,21 +510,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = WINDOWS_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.windows_prod_builder(
-        name = "Windows%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "tool_integration_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
     )
     common.windows_prod_builder(
         name = "Windows%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
@@ -633,25 +573,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.mac_prod_builder(
-        name = "Mac%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "build_tests",
-            "subshards": ["1_4", "2_4", "3_4", "4_4"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "gems"}, {"dependency": "goldctl"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_NEWXCODE_CACHES,
-        os = MAC_OS,
-    )
     common.builder_with_subshards(
         name = "Mac%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -672,25 +593,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = MAC_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.mac_prod_builder(
-        name = "Mac%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "framework_tests",
-            "subshards": ["libraries", "misc", "widgets"],
-            "dependencies": [{"dependency": "goldctl"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_DEFAULT_CACHES,
-        os = MAC_OS,
     )
     common.builder_with_subshards(
         name = "Mac%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
@@ -713,25 +615,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.mac_prod_builder(
-        name = "Mac%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "tool_tests",
-            "subshards": ["general", "commands"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_DEFAULT_CACHES,
-        os = MAC_OS,
-    )
     common.builder_with_subshards(
         name = "Mac%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -752,25 +635,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = MAC_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.mac_prod_builder(
-        name = "Mac%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "tool_integration_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "gems"}, {"dependency": "goldctl"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_DEFAULT_CACHES,
-        os = MAC_OS,
     )
     common.mac_prod_builder(
         name = "Mac%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
@@ -1079,24 +943,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.mac_try_builder(
-        name = "Mac build_tests|bld_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "build_tests",
-            "subshards": ["1_4", "2_4", "3_4", "4_4"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "gems"}, {"dependency": "goldctl"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_NEWXCODE_CACHES,
-        os = MAC_OS,
-    )
     common.builder_with_subshards(
         name = "Mac framework_tests|frwk_tests",
         recipe = "flutter/flutter_drone",
@@ -1115,23 +961,6 @@ def framework_try_config():
         os = MAC_OS,
         bucket = "try",
         branch_name = None,
-    )
-    common.mac_try_builder(
-        name = "Mac framework_tests|frwk_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "framework_tests",
-            "subshards": ["libraries", "misc", "widgets"],
-            "dependencies": [{"dependency": "goldctl"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_DEFAULT_CACHES,
-        os = MAC_OS,
     )
     common.builder_with_subshards(
         name = "Mac tool_tests|tool_tests",
@@ -1153,24 +982,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.mac_try_builder(
-        name = "Mac tool_tests|tool_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "tool_tests",
-            "subshards": ["general", "commands"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_DEFAULT_CACHES,
-        os = MAC_OS,
-    )
     common.builder_with_subshards(
         name = "Mac tool_integration_tests|tool_tests_int",
         recipe = "flutter/flutter_drone",
@@ -1190,24 +1001,6 @@ def framework_try_config():
         os = MAC_OS,
         bucket = "try",
         branch_name = None,
-    )
-    common.mac_try_builder(
-        name = "Mac tool_integration_tests|tool_tests_int",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "tool_integration_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "xcode"}, {"dependency": "gems"}, {"dependency": "goldctl"}],
-            "$flutter/osx_sdk": {
-                "sdk_version": XCODE_VERSION,
-            },
-        },
-        dimensions = {"device_type": "none"},
-        caches = MAC_DEFAULT_CACHES,
-        os = MAC_OS,
     )
     common.mac_try_builder(
         name = "Mac web_tool_tests|web_tt",
@@ -1271,19 +1064,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.windows_try_builder(
-        name = "Windows build_tests|bld_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "build_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
-    )
     common.builder_with_subshards(
         name = "Windows framework_tests|frwk_tests",
         recipe = "flutter/flutter_drone",
@@ -1298,19 +1078,6 @@ def framework_try_config():
         os = WINDOWS_OS,
         bucket = "try",
         branch_name = None,
-    )
-    common.windows_try_builder(
-        name = "Windows framework_tests|frwk_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "framework_tests",
-            "subshards": ["libraries", "misc", "widgets"],
-            "dependencies": [{"dependency": "goldctl"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
     )
     common.builder_with_subshards(
         name = "Windows tool_tests|tool_tests",
@@ -1328,20 +1095,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.windows_try_builder(
-        name = "Windows tool_tests|tool_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "tool_tests",
-            "subshards": ["general", "commands"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
-    )
     common.builder_with_subshards(
         name = "Windows tool_integration_tests|tool_tests_int",
         recipe = "flutter/flutter_drone",
@@ -1357,20 +1110,6 @@ def framework_try_config():
         os = WINDOWS_OS,
         bucket = "try",
         branch_name = None,
-    )
-    common.windows_try_builder(
-        name = "Windows tool_integration_tests|tool_tests_int",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "tool_integration_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}],
-        },
-        caches = WIN_DEFAULT_CACHES,
-        os = WINDOWS_OS,
     )
     common.windows_try_builder(
         name = "Windows web_tool_tests|web_tt",

--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -208,21 +208,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.linux_prod_builder(
-        name = "Linux%s build_tests|bld_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "build_tests",
-            "subshards": ["1_2", "2_2"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}, {"dependency": "clang"}, {"dependency": "cmake"}, {"dependency": "ninja"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
     common.builder_with_subshards(
         name = "Linux%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -239,21 +224,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = LINUX_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.linux_prod_builder(
-        name = "Linux%s framework_tests|frwk_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "framework_tests",
-            "subshards": ["libraries", "misc", "widgets"],
-            "dependencies": [{"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
     )
     common.builder_with_subshards(
         name = "Linux%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
@@ -272,21 +242,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.linux_prod_builder(
-        name = "Linux%s tool_tests|tool_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "tool_tests",
-            "subshards": ["general", "commands"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
     common.builder_with_subshards(
         name = "Linux%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -303,21 +258,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = LINUX_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.linux_prod_builder(
-        name = "Linux%s tool_integration_tests|tool_tests_int" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "tool_integration_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
     )
     common.linux_prod_builder(
         name = "Linux%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
@@ -366,21 +306,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
     )
-    common.linux_prod_builder(
-        name = "Linux%s web_tests|web_tests" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "shard": "web_tests",
-            "subshards": ["0", "1", "2", "3", "4", "5", "6", "7_last"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
     common.builder_with_subshards(
         name = "Linux%s web_long_running_tests|web_lrt" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
@@ -396,20 +321,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = LINUX_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-    )
-    common.linux_prod_builder(
-        name = "Linux%s web_long_running_tests|web_lrt" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        properties = {
-            "shard": "web_long_running_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
     )
     common.linux_prod_builder(
         name = "Linux%s SDK Drone|frwdrn" % ("" if branch == "master" else " " + branch),
@@ -940,20 +851,6 @@ def framework_try_config():
         branch_name = None,
     )
 
-    common.linux_try_builder(
-        name = "Linux build_tests|bld_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "build_tests",
-            "subshards": ["1_2", "2_2"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}, {"dependency": "clang"}, {"dependency": "cmake"}, {"dependency": "ninja"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-
     common.builder_with_subshards(
         name = "Linux framework_tests|frwk_tests",
         recipe = "flutter/flutter_drone",
@@ -969,20 +866,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.linux_try_builder(
-        name = "Linux framework_tests|frwk_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "framework_tests",
-            "subshards": ["libraries", "misc", "widgets"],
-            "dependencies": [{"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-
     common.builder_with_subshards(
         name = "Linux tool_tests|tool_tests",
         recipe = "flutter/flutter_drone",
@@ -999,21 +882,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.linux_try_builder(
-        name = "Linux tool_tests|tool_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "tool_tests",
-            "subshards": ["general", "commands"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "open_jdk"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-
     common.builder_with_subshards(
         name = "Linux tool_integration_tests|tool_tests_int",
         recipe = "flutter/flutter_drone",
@@ -1029,20 +897,6 @@ def framework_try_config():
         os = LINUX_OS,
         bucket = "try",
         branch_name = None,
-    )
-    common.linux_try_builder(
-        name = "Linux tool_integration_tests|tool_tests_int",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        add_cq = True,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "tool_integration_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
     )
     common.linux_try_builder(
         name = "Linux web_tool_tests|web_tt",
@@ -1073,20 +927,6 @@ def framework_try_config():
         bucket = "try",
         branch_name = None,
     )
-    common.linux_try_builder(
-        name = "Linux web_tests|web_tests",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "web_tests",
-            "subshards": ["0", "1", "2", "3", "4", "5", "6", "7_last"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-
     common.builder_with_subshards(
         name = "Linux web_long_running_tests|web_lrt",
         recipe = "flutter/flutter_drone",
@@ -1101,19 +941,6 @@ def framework_try_config():
         os = LINUX_OS,
         bucket = "try",
         branch_name = None,
-    )
-    common.linux_try_builder(
-        name = "Linux web_long_running_tests|web_lrt",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "shard": "web_long_running_tests",
-            "subshards": ["1_3", "2_3", "3_3"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
     )
     common.linux_try_builder(
         name = "Linux web_integration_tests|web_int",

--- a/config/generated/flutter/luci/commit-queue.cfg
+++ b/config/generated/flutter/luci/commit-queue.cfg
@@ -130,9 +130,6 @@ config_groups {
         name: "flutter/try/Mac build_aar_module_test"
       }
       builders {
-        name: "flutter/try/Mac build_tests"
-      }
-      builders {
         name: "flutter/try/Mac build_tests_1_4"
       }
       builders {
@@ -148,9 +145,6 @@ config_groups {
         name: "flutter/try/Mac customer_testing"
       }
       builders {
-        name: "flutter/try/Mac tool_integration_tests"
-      }
-      builders {
         name: "flutter/try/Mac tool_integration_tests_1_3"
       }
       builders {
@@ -158,9 +152,6 @@ config_groups {
       }
       builders {
         name: "flutter/try/Mac tool_integration_tests_3_3"
-      }
-      builders {
-        name: "flutter/try/Mac tool_tests"
       }
       builders {
         name: "flutter/try/Mac tool_tests_commands"
@@ -175,9 +166,6 @@ config_groups {
         name: "flutter/try/Windows customer_testing"
       }
       builders {
-        name: "flutter/try/Windows tool_integration_tests"
-      }
-      builders {
         name: "flutter/try/Windows tool_integration_tests_1_3"
       }
       builders {
@@ -185,9 +173,6 @@ config_groups {
       }
       builders {
         name: "flutter/try/Windows tool_integration_tests_3_3"
-      }
-      builders {
-        name: "flutter/try/Windows tool_tests"
       }
       builders {
         name: "flutter/try/Windows tool_tests_commands"

--- a/config/generated/flutter/luci/commit-queue.cfg
+++ b/config/generated/flutter/luci/commit-queue.cfg
@@ -112,9 +112,6 @@ config_groups {
         name: "flutter/try/Linux build_aar_module_test"
       }
       builders {
-        name: "flutter/try/Linux tool_integration_tests"
-      }
-      builders {
         name: "flutter/try/Linux tool_integration_tests_1_3"
       }
       builders {
@@ -122,9 +119,6 @@ config_groups {
       }
       builders {
         name: "flutter/try/Linux tool_integration_tests_3_3"
-      }
-      builders {
-        name: "flutter/try/Linux tool_tests"
       }
       builders {
         name: "flutter/try/Linux tool_tests_commands"

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -21037,64 +21037,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac beta build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_4\",\"2_4\",\"3_4\",\"4_4\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "new_osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac beta build_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -21407,64 +21349,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "use_cas:true"
       }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac beta framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -22388,64 +22272,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac beta tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac beta tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -22583,64 +22409,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac beta tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -22987,64 +22755,6 @@ buckets {
       caches {
         name: "osx_sdk"
         path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_4\",\"2_4\",\"3_4\",\"4_4\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "new_osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
       }
       caches {
         name: "pub_cache"
@@ -23768,64 +23478,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac dev build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_4\",\"2_4\",\"3_4\",\"4_4\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "new_osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac dev build_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -24138,64 +23790,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "use_cas:true"
       }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac dev framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -25119,64 +24713,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac dev tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac dev tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -25314,64 +24850,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac dev tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -25582,64 +25060,6 @@ buckets {
         properties_j: "upload_packages:true"
       }
       priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -26926,64 +26346,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac stable build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_4\",\"2_4\",\"3_4\",\"4_4\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "new_osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac stable build_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -27296,64 +26658,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "use_cas:true"
       }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac stable framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -28277,64 +27581,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac stable tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac stable tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -28472,64 +27718,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac stable tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -28774,64 +27962,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -28969,64 +28099,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -50134,54 +49206,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows beta build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows beta build_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -50345,54 +49369,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows beta framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -50949,54 +49925,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows beta tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows beta tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -51112,54 +50040,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows beta tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -51353,54 +50233,6 @@ buckets {
         properties_j: "task_name:\"build_aar_module_test\""
         properties_j: "upload_packages:true"
         properties_j: "use_cas:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 30
       execution_timeout_secs: 3600
@@ -51832,54 +50664,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows dev build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows dev build_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -52043,54 +50827,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows dev framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -52647,54 +51383,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows dev tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows dev tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -52810,54 +51498,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows dev tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -53005,54 +51645,6 @@ buckets {
         properties_j: "upload_packages:true"
       }
       priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -53866,54 +52458,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows stable build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows stable build_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -54077,54 +52621,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"customer_testing\""
         properties_j: "validation_name:\"Customer testing\""
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows stable framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -54681,54 +53177,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows stable tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows stable tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -54844,54 +53292,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows stable tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -55065,54 +53465,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -55228,54 +53580,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -58694,63 +56998,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_4\",\"2_4\",\"3_4\",\"4_4\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "new_osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac build_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -59111,63 +57358,6 @@ buckets {
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
       build_numbers: YES
       service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
       task_template_canary_percentage {}
@@ -59959,63 +58149,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Mac tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"xcode\"},{\"dependency\":\"gems\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Mac tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "device_type:none"
@@ -60151,63 +58284,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "osx_sdk"
-        path: "osx_sdk"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      caches {
-        name: "xcode_binary"
-        path: "xcode_binary"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Mac tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "device_type:none"
-      dimensions: "os:Mac-10.15"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$flutter/osx_sdk:{\"sdk_version\":\"12c33\"}"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
@@ -60652,53 +58728,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows build_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -60905,53 +58934,6 @@ buckets {
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
       build_numbers: YES
       service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
       task_template_canary_percentage {}
@@ -61520,53 +59502,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Windows tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Windows tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Windows-Server"
@@ -61680,53 +59615,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Windows tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Windows-Server"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"}]"
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -1907,55 +1907,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"clang\"},{\"dependency\":\"cmake\"},{\"dependency\":\"ninja\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_2\",\"2_2\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta build_tests_1_2"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -3633,55 +3584,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta framework_tests_libraries"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -4930,55 +4832,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -5097,55 +4950,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux beta tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -5471,54 +5275,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta web_long_running_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_long_running_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta web_long_running_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -5735,55 +5491,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"web_smoke_test\""
         properties_j: "validation_name:\"Web smoke tests\""
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux beta web_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_27_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_tests\""
-        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -6274,55 +5981,6 @@ buckets {
         properties_j: "task_name:\"build_aar_module_test\""
         properties_j: "upload_packages:true"
         properties_j: "use_cas:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"clang\"},{\"dependency\":\"cmake\"},{\"dependency\":\"ninja\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_2\",\"2_2\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 30
       execution_timeout_secs: 3600
@@ -7826,55 +7484,6 @@ buckets {
         properties_j: "task_name:\"build_aar_module_test\""
         properties_j: "upload_packages:true"
         properties_j: "use_cas:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux dev build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"clang\"},{\"dependency\":\"cmake\"},{\"dependency\":\"ninja\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_2\",\"2_2\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -9580,55 +9189,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux dev framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux dev framework_tests_libraries"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -10877,55 +10437,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux dev tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux dev tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -11044,55 +10555,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux dev tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -11418,54 +10880,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux dev web_long_running_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_long_running_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux dev web_long_running_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -11682,55 +11096,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"web_smoke_test\""
         properties_j: "validation_name:\"Web smoke tests\""
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux dev web_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_tests\""
-        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -13297,55 +12662,6 @@ buckets {
       }
       execution_timeout_secs: 1800
       expiration_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
         path: "android"
@@ -15451,55 +14767,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"clang\"},{\"dependency\":\"cmake\"},{\"dependency\":\"ninja\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_2\",\"2_2\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable build_tests_1_2"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -17227,55 +16494,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable framework_tests_libraries"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -18524,55 +17742,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -18691,55 +17860,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux stable tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 29
@@ -19065,54 +18185,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable web_long_running_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_long_running_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable web_long_running_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -19329,55 +18401,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"web_smoke_test\""
         properties_j: "validation_name:\"Web smoke tests\""
-      }
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux stable web_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter_1_26_0"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_tests\""
-        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 29
       execution_timeout_secs: 3600
@@ -19948,55 +18971,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -20115,55 +19089,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:true"
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:true"
       }
       priority: 30
@@ -20489,54 +19414,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_long_running_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_long_running_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:true"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_long_running_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -20753,55 +19630,6 @@ buckets {
         properties_j: "upload_packages:true"
         properties_j: "validation:\"web_smoke_test\""
         properties_j: "validation_name:\"Web smoke tests\""
-      }
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux web_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:false"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_tests\""
-        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
-        properties_j: "upload_packages:true"
       }
       priority: 30
       execution_timeout_secs: 3600
@@ -57404,54 +56232,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux build_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"clang\"},{\"dependency\":\"cmake\"},{\"dependency\":\"ninja\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"build_tests\""
-        properties_j: "subshards:[\"1_2\",\"2_2\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux build_tests_1_2"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -57798,54 +56578,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"flutter_plugins\""
         properties_j: "subshard:\"analyze\""
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux framework_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"framework_tests\""
-        properties_j: "subshards:[\"libraries\",\"misc\",\"widgets\"]"
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
@@ -58594,54 +57326,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux tool_integration_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_integration_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux tool_integration_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -58758,54 +57442,6 @@ buckets {
         properties_j: "mastername:\"client.flutter\""
         properties_j: "shard:\"tool_integration_tests\""
         properties_j: "subshard:\"3_3\""
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux tool_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"tool_tests\""
-        properties_j: "subshards:[\"general\",\"commands\"]"
         properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
@@ -59074,54 +57710,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_long_running_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_long_running_tests\""
-        properties_j: "subshards:[\"1_3\",\"2_3\",\"3_3\"]"
-        properties_j: "upload_packages:false"
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_long_running_tests_1_3"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -59287,54 +57875,6 @@ buckets {
         properties_j: "upload_packages:false"
         properties_j: "validation:\"web_smoke_test\""
         properties_j: "validation_name:\"Web smoke tests\""
-      }
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux web_tests"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      recipe {
-        name: "flutter/flutter"
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        properties_j: "$fuchsia/goma:{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"}"
-        properties_j: "$kitchen:{\"emulate_gce\":true}"
-        properties_j: "$recipe_engine/isolated:{\"server\":\"https://isolateserver.appspot.com\"}"
-        properties_j: "$recipe_engine/swarming:{\"server\":\"https://chromium-swarm.appspot.com\"}"
-        properties_j: "clobber:false"
-        properties_j: "dependencies:[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}]"
-        properties_j: "fuchsia_ctl_version:\"version:0.0.23\""
-        properties_j: "gold_tryjob:true"
-        properties_j: "goma_jobs:\"200\""
-        properties_j: "mastername:\"client.flutter\""
-        properties_j: "shard:\"web_tests\""
-        properties_j: "subshards:[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7_last\"]"
-        properties_j: "upload_packages:false"
       }
       execution_timeout_secs: 3600
       caches {

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -4344,11 +4344,6 @@ consoles {
     short_name: "bt22"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable build_tests"
-    category: "Linux"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable framework_tests_libraries"
     category: "Linux"
     short_name: "ftl"
@@ -4364,11 +4359,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable framework_tests"
-    category: "Linux"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable tool_tests_general"
     category: "Linux"
     short_name: "ttg"
@@ -4377,11 +4367,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux stable tool_tests_commands"
     category: "Linux"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable tool_tests"
-    category: "Linux"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable tool_integration_tests_1_3"
@@ -4397,11 +4382,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux stable tool_integration_tests_3_3"
     category: "Linux"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable tool_integration_tests"
-    category: "Linux"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_tool_tests"
@@ -4454,11 +4434,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_tests"
-    category: "Linux"
-    short_name: "web_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests_1_3"
     category: "Linux"
     short_name: "wlrt1"
@@ -4472,11 +4447,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests_3_3"
     category: "Linux"
     short_name: "wlrt3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests"
-    category: "Linux"
-    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux stable analyze"
@@ -4712,11 +4682,6 @@ consoles {
     short_name: "bt22"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta build_tests"
-    category: "Linux"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux beta framework_tests_libraries"
     category: "Linux"
     short_name: "ftl"
@@ -4732,11 +4697,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta framework_tests"
-    category: "Linux"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux beta tool_tests_general"
     category: "Linux"
     short_name: "ttg"
@@ -4745,11 +4705,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta tool_tests_commands"
     category: "Linux"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta tool_tests"
-    category: "Linux"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta tool_integration_tests_1_3"
@@ -4765,11 +4720,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta tool_integration_tests_3_3"
     category: "Linux"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta tool_integration_tests"
-    category: "Linux"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_tool_tests"
@@ -4822,11 +4772,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_tests"
-    category: "Linux"
-    short_name: "web_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests_1_3"
     category: "Linux"
     short_name: "wlrt1"
@@ -4840,11 +4785,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests_3_3"
     category: "Linux"
     short_name: "wlrt3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests"
-    category: "Linux"
-    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta analyze"
@@ -5080,11 +5020,6 @@ consoles {
     short_name: "bt22"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev build_tests"
-    category: "Linux"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev framework_tests_libraries"
     category: "Linux"
     short_name: "ftl"
@@ -5100,11 +5035,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev framework_tests"
-    category: "Linux"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev tool_tests_general"
     category: "Linux"
     short_name: "ttg"
@@ -5113,11 +5043,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux dev tool_tests_commands"
     category: "Linux"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev tool_tests"
-    category: "Linux"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev tool_integration_tests_1_3"
@@ -5133,11 +5058,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux dev tool_integration_tests_3_3"
     category: "Linux"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev tool_integration_tests"
-    category: "Linux"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_tool_tests"
@@ -5190,11 +5110,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_tests"
-    category: "Linux"
-    short_name: "web_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests_1_3"
     category: "Linux"
     short_name: "wlrt1"
@@ -5208,11 +5123,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests_3_3"
     category: "Linux"
     short_name: "wlrt3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests"
-    category: "Linux"
-    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux dev analyze"
@@ -5443,11 +5353,6 @@ consoles {
     short_name: "bt22"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux build_tests"
-    category: "Linux"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux framework_tests_libraries"
     category: "Linux"
     short_name: "ftl"
@@ -5463,11 +5368,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux framework_tests"
-    category: "Linux"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux tool_tests_general"
     category: "Linux"
     short_name: "ttg"
@@ -5476,11 +5376,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux tool_tests_commands"
     category: "Linux"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux tool_tests"
-    category: "Linux"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux tool_integration_tests_1_3"
@@ -5496,11 +5391,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux tool_integration_tests_3_3"
     category: "Linux"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux tool_integration_tests"
-    category: "Linux"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux web_tool_tests"
@@ -5553,11 +5443,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_tests"
-    category: "Linux"
-    short_name: "web_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests_1_3"
     category: "Linux"
     short_name: "wlrt1"
@@ -5571,11 +5456,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests_3_3"
     category: "Linux"
     short_name: "wlrt3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests"
-    category: "Linux"
-    short_name: "web_lrt"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux analyze"
@@ -5799,9 +5679,6 @@ consoles {
     name: "buildbucket/luci.flutter.try/Linux build_tests_2_2"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Linux build_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Linux framework_tests_libraries"
   }
   builders {
@@ -5811,16 +5688,10 @@ consoles {
     name: "buildbucket/luci.flutter.try/Linux framework_tests_widgets"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Linux framework_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Linux tool_tests_general"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux tool_tests_commands"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux tool_integration_tests_1_3"
@@ -5830,9 +5701,6 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux tool_integration_tests_3_3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux tool_integration_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_tool_tests"
@@ -5862,9 +5730,6 @@ consoles {
     name: "buildbucket/luci.flutter.try/Linux web_tests_7_last"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Linux web_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Linux web_long_running_tests_1_3"
   }
   builders {
@@ -5872,9 +5737,6 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_long_running_tests_3_3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux web_long_running_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_integration_tests"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -4499,11 +4499,6 @@ consoles {
     short_name: "bt33"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows stable build_tests"
-    category: "Windows"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows stable framework_tests_libraries"
     category: "Windows"
     short_name: "ftl"
@@ -4519,11 +4514,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows stable framework_tests"
-    category: "Windows"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows stable tool_tests_general"
     category: "Windows"
     short_name: "ttg"
@@ -4532,11 +4522,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows stable tool_tests_commands"
     category: "Windows"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows stable tool_tests"
-    category: "Windows"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests_1_3"
@@ -4552,11 +4537,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests_3_3"
     category: "Windows"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows stable tool_integration_tests"
-    category: "Windows"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows stable web_tool_tests"
@@ -4589,11 +4569,6 @@ consoles {
     short_name: "bt44"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac stable build_tests"
-    category: "Mac"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac stable framework_tests_libraries"
     category: "Mac"
     short_name: "ftl"
@@ -4609,11 +4584,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac stable framework_tests"
-    category: "Mac"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_tests_general"
     category: "Mac"
     short_name: "ttg"
@@ -4622,11 +4592,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_tests_commands"
     category: "Mac"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac stable tool_tests"
-    category: "Mac"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests_1_3"
@@ -4642,11 +4607,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests_3_3"
     category: "Mac"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac stable tool_integration_tests"
-    category: "Mac"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac stable web_tool_tests"
@@ -4837,11 +4797,6 @@ consoles {
     short_name: "bt33"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows beta build_tests"
-    category: "Windows"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows beta framework_tests_libraries"
     category: "Windows"
     short_name: "ftl"
@@ -4857,11 +4812,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows beta framework_tests"
-    category: "Windows"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows beta tool_tests_general"
     category: "Windows"
     short_name: "ttg"
@@ -4870,11 +4820,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows beta tool_tests_commands"
     category: "Windows"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows beta tool_tests"
-    category: "Windows"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests_1_3"
@@ -4890,11 +4835,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests_3_3"
     category: "Windows"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows beta tool_integration_tests"
-    category: "Windows"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows beta web_tool_tests"
@@ -4927,11 +4867,6 @@ consoles {
     short_name: "bt44"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac beta build_tests"
-    category: "Mac"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac beta framework_tests_libraries"
     category: "Mac"
     short_name: "ftl"
@@ -4947,11 +4882,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac beta framework_tests"
-    category: "Mac"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_tests_general"
     category: "Mac"
     short_name: "ttg"
@@ -4960,11 +4890,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_tests_commands"
     category: "Mac"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac beta tool_tests"
-    category: "Mac"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests_1_3"
@@ -4980,11 +4905,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests_3_3"
     category: "Mac"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac beta tool_integration_tests"
-    category: "Mac"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac beta web_tool_tests"
@@ -5175,11 +5095,6 @@ consoles {
     short_name: "bt33"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows dev build_tests"
-    category: "Windows"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows dev framework_tests_libraries"
     category: "Windows"
     short_name: "ftl"
@@ -5195,11 +5110,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows dev framework_tests"
-    category: "Windows"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows dev tool_tests_general"
     category: "Windows"
     short_name: "ttg"
@@ -5208,11 +5118,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows dev tool_tests_commands"
     category: "Windows"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows dev tool_tests"
-    category: "Windows"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests_1_3"
@@ -5228,11 +5133,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests_3_3"
     category: "Windows"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows dev tool_integration_tests"
-    category: "Windows"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows dev web_tool_tests"
@@ -5265,11 +5165,6 @@ consoles {
     short_name: "bt44"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac dev build_tests"
-    category: "Mac"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac dev framework_tests_libraries"
     category: "Mac"
     short_name: "ftl"
@@ -5285,11 +5180,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac dev framework_tests"
-    category: "Mac"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_tests_general"
     category: "Mac"
     short_name: "ttg"
@@ -5298,11 +5188,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_tests_commands"
     category: "Mac"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac dev tool_tests"
-    category: "Mac"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests_1_3"
@@ -5318,11 +5203,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests_3_3"
     category: "Mac"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac dev tool_integration_tests"
-    category: "Mac"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac dev web_tool_tests"
@@ -5508,11 +5388,6 @@ consoles {
     short_name: "bt33"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows build_tests"
-    category: "Windows"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows framework_tests_libraries"
     category: "Windows"
     short_name: "ftl"
@@ -5528,11 +5403,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Windows framework_tests"
-    category: "Windows"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Windows tool_tests_general"
     category: "Windows"
     short_name: "ttg"
@@ -5541,11 +5411,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows tool_tests_commands"
     category: "Windows"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows tool_tests"
-    category: "Windows"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests_1_3"
@@ -5561,11 +5426,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests_3_3"
     category: "Windows"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Windows tool_integration_tests"
-    category: "Windows"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Windows web_tool_tests"
@@ -5598,11 +5458,6 @@ consoles {
     short_name: "bt44"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac build_tests"
-    category: "Mac"
-    short_name: "bld_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac framework_tests_libraries"
     category: "Mac"
     short_name: "ftl"
@@ -5618,11 +5473,6 @@ consoles {
     short_name: "ftw"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Mac framework_tests"
-    category: "Mac"
-    short_name: "frwk_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Mac tool_tests_general"
     category: "Mac"
     short_name: "ttg"
@@ -5631,11 +5481,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac tool_tests_commands"
     category: "Mac"
     short_name: "ttc"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac tool_tests"
-    category: "Mac"
-    short_name: "tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests_1_3"
@@ -5651,11 +5496,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests_3_3"
     category: "Mac"
     short_name: "tit33"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Mac tool_integration_tests"
-    category: "Mac"
-    short_name: "tool_tests_int"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Mac web_tool_tests"
@@ -5778,9 +5618,6 @@ consoles {
     name: "buildbucket/luci.flutter.try/Mac build_tests_4_4"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Mac build_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Mac framework_tests_libraries"
   }
   builders {
@@ -5790,16 +5627,10 @@ consoles {
     name: "buildbucket/luci.flutter.try/Mac framework_tests_widgets"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Mac framework_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Mac tool_tests_general"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac tool_tests_commands"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Mac tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac tool_integration_tests_1_3"
@@ -5809,9 +5640,6 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac tool_integration_tests_3_3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Mac tool_integration_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac web_tool_tests"
@@ -5832,9 +5660,6 @@ consoles {
     name: "buildbucket/luci.flutter.try/Windows build_tests_3_3"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Windows build_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Windows framework_tests_libraries"
   }
   builders {
@@ -5844,16 +5669,10 @@ consoles {
     name: "buildbucket/luci.flutter.try/Windows framework_tests_widgets"
   }
   builders {
-    name: "buildbucket/luci.flutter.try/Windows framework_tests"
-  }
-  builders {
     name: "buildbucket/luci.flutter.try/Windows tool_tests_general"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows tool_tests_commands"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Windows tool_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows tool_integration_tests_1_3"
@@ -5863,9 +5682,6 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows tool_integration_tests_3_3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Windows tool_integration_tests"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Windows web_tool_tests"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -4697,17 +4697,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac beta build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac beta build_tests_1_4"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4764,17 +4753,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac beta dart_plugin_registry_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac beta framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4961,17 +4939,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac beta tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac beta tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4995,17 +4962,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac beta tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac beta tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5072,17 +5028,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac build_ios_framework_module_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5225,17 +5170,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac dev build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac dev build_tests_1_4"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5292,17 +5226,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac dev dart_plugin_registry_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac dev framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5489,17 +5412,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac dev tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac dev tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5523,17 +5435,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac dev tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac dev tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5578,17 +5479,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac dev web_tool_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -5841,17 +5731,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac stable build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac stable build_tests_1_4"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -5908,17 +5787,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac stable dart_plugin_registry_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac stable framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -6105,17 +5973,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac stable tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac stable tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -6139,17 +5996,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac stable tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac stable tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -6204,17 +6050,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Mac tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Mac tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -6238,17 +6073,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Mac tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Mac tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10604,17 +10428,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows beta build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows beta build_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -10649,17 +10462,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows beta customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows beta framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10791,17 +10593,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows beta tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows beta tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -10825,17 +10616,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows beta tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows beta tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10880,17 +10660,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows build_aar_module_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -10989,17 +10758,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows dev build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows dev build_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -11034,17 +10792,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows dev customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows dev framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -11176,17 +10923,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows dev tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows dev tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -11220,17 +10956,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows dev tool_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows dev tool_tests_commands"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -11254,17 +10979,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows dev web_tool_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -11451,17 +11165,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows stable build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows stable build_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -11496,17 +11199,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows stable customer_testing"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows stable framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -11638,17 +11330,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows stable tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows stable tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -11672,17 +11353,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows stable tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows stable tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -11726,17 +11396,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Windows tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Windows tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -11760,17 +11419,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Windows tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Windows tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -451,17 +451,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta build_tests_1_2"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -836,17 +825,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta framework_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta framework_tests_libraries"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1122,17 +1100,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1156,17 +1123,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux beta tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux beta tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1243,17 +1199,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta web_long_running_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta web_long_running_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1299,17 +1244,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux beta web_smoke_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux beta web_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1420,17 +1354,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux build_aar_module_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -1761,17 +1684,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev build_aar_module_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux dev build_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2156,17 +2068,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux dev framework_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux dev framework_tests_libraries"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2442,17 +2343,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux dev tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux dev tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2476,17 +2366,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux dev tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2563,17 +2442,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux dev web_long_running_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux dev web_long_running_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2619,17 +2487,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev web_smoke_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux dev web_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2982,17 +2839,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux frame_policy_delay_test_android"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux framework_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -3465,17 +3311,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable build_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable build_tests_1_2"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -3861,17 +3696,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable framework_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable framework_tests_libraries"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4147,17 +3971,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4181,17 +3994,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux stable tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux stable tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4268,17 +4070,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable web_long_running_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable web_long_running_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4324,17 +4115,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux stable web_smoke_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux stable web_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4466,17 +4246,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux tool_integration_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux tool_integration_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4500,17 +4269,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux tool_integration_tests_3_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux tool_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4587,17 +4345,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux web_long_running_tests"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux web_long_running_tests_1_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4643,17 +4390,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux web_smoke_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux web_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -5927,20 +5927,6 @@ job {
   }
 }
 job {
-  id: "Mac beta build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac beta build_tests"
-  }
-}
-job {
   id: "Mac beta build_tests_1_4"
   acl_sets: "prod"
   triggering_policy {
@@ -6022,20 +6008,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac beta dart_plugin_registry_test"
-  }
-}
-job {
-  id: "Mac beta framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac beta framework_tests"
   }
 }
 job {
@@ -6260,20 +6232,6 @@ job {
   }
 }
 job {
-  id: "Mac beta tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac beta tool_integration_tests"
-  }
-}
-job {
   id: "Mac beta tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -6313,20 +6271,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac beta tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Mac beta tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac beta tool_tests"
   }
 }
 job {
@@ -6411,20 +6355,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac build_ios_framework_module_test"
-  }
-}
-job {
-  id: "Mac build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac build_tests"
   }
 }
 job {
@@ -6592,20 +6522,6 @@ job {
   }
 }
 job {
-  id: "Mac dev build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac dev build_tests"
-  }
-}
-job {
   id: "Mac dev build_tests_1_4"
   acl_sets: "prod"
   triggering_policy {
@@ -6687,20 +6603,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev dart_plugin_registry_test"
-  }
-}
-job {
-  id: "Mac dev framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac dev framework_tests"
   }
 }
 job {
@@ -6925,20 +6827,6 @@ job {
   }
 }
 job {
-  id: "Mac dev tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac dev tool_integration_tests"
-  }
-}
-job {
   id: "Mac dev tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -6978,20 +6866,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Mac dev tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac dev tool_tests"
   }
 }
 job {
@@ -7048,20 +6922,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac dev web_tool_tests"
-  }
-}
-job {
-  id: "Mac framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac framework_tests"
   }
 }
 job {
@@ -7369,20 +7229,6 @@ job {
   }
 }
 job {
-  id: "Mac stable build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac stable build_tests"
-  }
-}
-job {
   id: "Mac stable build_tests_1_4"
   acl_sets: "prod"
   triggering_policy {
@@ -7464,20 +7310,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac stable dart_plugin_registry_test"
-  }
-}
-job {
-  id: "Mac stable framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac stable framework_tests"
   }
 }
 job {
@@ -7702,20 +7534,6 @@ job {
   }
 }
 job {
-  id: "Mac stable tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac stable tool_integration_tests"
-  }
-}
-job {
   id: "Mac stable tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -7755,20 +7573,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac stable tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Mac stable tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac stable tool_tests"
   }
 }
 job {
@@ -7828,20 +7632,6 @@ job {
   }
 }
 job {
-  id: "Mac tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac tool_integration_tests"
-  }
-}
-job {
   id: "Mac tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -7881,20 +7671,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Mac tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Mac tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Mac tool_tests"
   }
 }
 job {
@@ -13422,20 +13198,6 @@ job {
   }
 }
 job {
-  id: "Windows beta build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows beta build_tests"
-  }
-}
-job {
   id: "Windows beta build_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -13489,20 +13251,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows beta customer_testing"
-  }
-}
-job {
-  id: "Windows beta framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows beta framework_tests"
   }
 }
 job {
@@ -13660,20 +13408,6 @@ job {
   }
 }
 job {
-  id: "Windows beta tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows beta tool_integration_tests"
-  }
-}
-job {
   id: "Windows beta tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -13713,20 +13447,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows beta tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Windows beta tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows beta tool_tests"
   }
 }
 job {
@@ -13783,20 +13503,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows build_aar_module_test"
-  }
-}
-job {
-  id: "Windows build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows build_tests"
   }
 }
 job {
@@ -13909,20 +13615,6 @@ job {
   }
 }
 job {
-  id: "Windows dev build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows dev build_tests"
-  }
-}
-job {
   id: "Windows dev build_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -13976,20 +13668,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows dev customer_testing"
-  }
-}
-job {
-  id: "Windows dev framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows dev framework_tests"
   }
 }
 job {
@@ -14147,20 +13825,6 @@ job {
   }
 }
 job {
-  id: "Windows dev tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows dev tool_integration_tests"
-  }
-}
-job {
   id: "Windows dev tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -14203,20 +13867,6 @@ job {
   }
 }
 job {
-  id: "Windows dev tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows dev tool_tests"
-  }
-}
-job {
   id: "Windows dev tool_tests_commands"
   acl_sets: "prod"
   triggering_policy {
@@ -14256,20 +13906,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows dev web_tool_tests"
-  }
-}
-job {
-  id: "Windows framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows framework_tests"
   }
 }
 job {
@@ -14494,20 +14130,6 @@ job {
   }
 }
 job {
-  id: "Windows stable build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows stable build_tests"
-  }
-}
-job {
   id: "Windows stable build_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -14561,20 +14183,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows stable customer_testing"
-  }
-}
-job {
-  id: "Windows stable framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows stable framework_tests"
   }
 }
 job {
@@ -14732,20 +14340,6 @@ job {
   }
 }
 job {
-  id: "Windows stable tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows stable tool_integration_tests"
-  }
-}
-job {
   id: "Windows stable tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -14785,20 +14379,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows stable tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Windows stable tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows stable tool_tests"
   }
 }
 job {
@@ -14844,20 +14424,6 @@ job {
   }
 }
 job {
-  id: "Windows tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows tool_integration_tests"
-  }
-}
-job {
   id: "Windows tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -14897,20 +14463,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Windows tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Windows tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Windows tool_tests"
   }
 }
 job {
@@ -15301,38 +14853,30 @@ trigger {
   triggers: "Linux beta web_tests_6"
   triggers: "Linux beta web_tests_7_last"
   triggers: "Linux beta web_tool_tests"
-  triggers: "Mac beta build_tests"
   triggers: "Mac beta build_tests_1_4"
   triggers: "Mac beta build_tests_2_4"
   triggers: "Mac beta build_tests_3_4"
   triggers: "Mac beta build_tests_4_4"
   triggers: "Mac beta customer_testing"
-  triggers: "Mac beta framework_tests"
   triggers: "Mac beta framework_tests_libraries"
   triggers: "Mac beta framework_tests_misc"
   triggers: "Mac beta framework_tests_widgets"
-  triggers: "Mac beta tool_integration_tests"
   triggers: "Mac beta tool_integration_tests_1_3"
   triggers: "Mac beta tool_integration_tests_2_3"
   triggers: "Mac beta tool_integration_tests_3_3"
-  triggers: "Mac beta tool_tests"
   triggers: "Mac beta tool_tests_commands"
   triggers: "Mac beta tool_tests_general"
   triggers: "Mac beta web_tool_tests"
-  triggers: "Windows beta build_tests"
   triggers: "Windows beta build_tests_1_3"
   triggers: "Windows beta build_tests_2_3"
   triggers: "Windows beta build_tests_3_3"
   triggers: "Windows beta customer_testing"
-  triggers: "Windows beta framework_tests"
   triggers: "Windows beta framework_tests_libraries"
   triggers: "Windows beta framework_tests_misc"
   triggers: "Windows beta framework_tests_widgets"
-  triggers: "Windows beta tool_integration_tests"
   triggers: "Windows beta tool_integration_tests_1_3"
   triggers: "Windows beta tool_integration_tests_2_3"
   triggers: "Windows beta tool_integration_tests_3_3"
-  triggers: "Windows beta tool_tests"
   triggers: "Windows beta tool_tests_commands"
   triggers: "Windows beta tool_tests_general"
   triggers: "Windows beta web_tool_tests"
@@ -15589,38 +15133,30 @@ trigger {
   triggers: "Linux dev web_tests_6"
   triggers: "Linux dev web_tests_7_last"
   triggers: "Linux dev web_tool_tests"
-  triggers: "Mac dev build_tests"
   triggers: "Mac dev build_tests_1_4"
   triggers: "Mac dev build_tests_2_4"
   triggers: "Mac dev build_tests_3_4"
   triggers: "Mac dev build_tests_4_4"
   triggers: "Mac dev customer_testing"
-  triggers: "Mac dev framework_tests"
   triggers: "Mac dev framework_tests_libraries"
   triggers: "Mac dev framework_tests_misc"
   triggers: "Mac dev framework_tests_widgets"
-  triggers: "Mac dev tool_integration_tests"
   triggers: "Mac dev tool_integration_tests_1_3"
   triggers: "Mac dev tool_integration_tests_2_3"
   triggers: "Mac dev tool_integration_tests_3_3"
-  triggers: "Mac dev tool_tests"
   triggers: "Mac dev tool_tests_commands"
   triggers: "Mac dev tool_tests_general"
   triggers: "Mac dev web_tool_tests"
-  triggers: "Windows dev build_tests"
   triggers: "Windows dev build_tests_1_3"
   triggers: "Windows dev build_tests_2_3"
   triggers: "Windows dev build_tests_3_3"
   triggers: "Windows dev customer_testing"
-  triggers: "Windows dev framework_tests"
   triggers: "Windows dev framework_tests_libraries"
   triggers: "Windows dev framework_tests_misc"
   triggers: "Windows dev framework_tests_widgets"
-  triggers: "Windows dev tool_integration_tests"
   triggers: "Windows dev tool_integration_tests_1_3"
   triggers: "Windows dev tool_integration_tests_2_3"
   triggers: "Windows dev tool_integration_tests_3_3"
-  triggers: "Windows dev tool_tests"
   triggers: "Windows dev tool_tests_commands"
   triggers: "Windows dev tool_tests_general"
   triggers: "Windows dev web_tool_tests"
@@ -16047,38 +15583,30 @@ trigger {
   triggers: "Linux web_tests_6"
   triggers: "Linux web_tests_7_last"
   triggers: "Linux web_tool_tests"
-  triggers: "Mac build_tests"
   triggers: "Mac build_tests_1_4"
   triggers: "Mac build_tests_2_4"
   triggers: "Mac build_tests_3_4"
   triggers: "Mac build_tests_4_4"
   triggers: "Mac customer_testing"
-  triggers: "Mac framework_tests"
   triggers: "Mac framework_tests_libraries"
   triggers: "Mac framework_tests_misc"
   triggers: "Mac framework_tests_widgets"
-  triggers: "Mac tool_integration_tests"
   triggers: "Mac tool_integration_tests_1_3"
   triggers: "Mac tool_integration_tests_2_3"
   triggers: "Mac tool_integration_tests_3_3"
-  triggers: "Mac tool_tests"
   triggers: "Mac tool_tests_commands"
   triggers: "Mac tool_tests_general"
   triggers: "Mac web_tool_tests"
-  triggers: "Windows build_tests"
   triggers: "Windows build_tests_1_3"
   triggers: "Windows build_tests_2_3"
   triggers: "Windows build_tests_3_3"
   triggers: "Windows customer_testing"
-  triggers: "Windows framework_tests"
   triggers: "Windows framework_tests_libraries"
   triggers: "Windows framework_tests_misc"
   triggers: "Windows framework_tests_widgets"
-  triggers: "Windows tool_integration_tests"
   triggers: "Windows tool_integration_tests_1_3"
   triggers: "Windows tool_integration_tests_2_3"
   triggers: "Windows tool_integration_tests_3_3"
-  triggers: "Windows tool_tests"
   triggers: "Windows tool_tests_commands"
   triggers: "Windows tool_tests_general"
   triggers: "Windows web_tool_tests"
@@ -16342,38 +15870,30 @@ trigger {
   triggers: "Linux stable web_tests_6"
   triggers: "Linux stable web_tests_7_last"
   triggers: "Linux stable web_tool_tests"
-  triggers: "Mac stable build_tests"
   triggers: "Mac stable build_tests_1_4"
   triggers: "Mac stable build_tests_2_4"
   triggers: "Mac stable build_tests_3_4"
   triggers: "Mac stable build_tests_4_4"
   triggers: "Mac stable customer_testing"
-  triggers: "Mac stable framework_tests"
   triggers: "Mac stable framework_tests_libraries"
   triggers: "Mac stable framework_tests_misc"
   triggers: "Mac stable framework_tests_widgets"
-  triggers: "Mac stable tool_integration_tests"
   triggers: "Mac stable tool_integration_tests_1_3"
   triggers: "Mac stable tool_integration_tests_2_3"
   triggers: "Mac stable tool_integration_tests_3_3"
-  triggers: "Mac stable tool_tests"
   triggers: "Mac stable tool_tests_commands"
   triggers: "Mac stable tool_tests_general"
   triggers: "Mac stable web_tool_tests"
-  triggers: "Windows stable build_tests"
   triggers: "Windows stable build_tests_1_3"
   triggers: "Windows stable build_tests_2_3"
   triggers: "Windows stable build_tests_3_3"
   triggers: "Windows stable customer_testing"
-  triggers: "Windows stable framework_tests"
   triggers: "Windows stable framework_tests_libraries"
   triggers: "Windows stable framework_tests_misc"
   triggers: "Windows stable framework_tests_widgets"
-  triggers: "Windows stable tool_integration_tests"
   triggers: "Windows stable tool_integration_tests_1_3"
   triggers: "Windows stable tool_integration_tests_2_3"
   triggers: "Windows stable tool_integration_tests_3_3"
-  triggers: "Windows stable tool_tests"
   triggers: "Windows stable tool_tests_commands"
   triggers: "Windows stable tool_tests_general"
   triggers: "Windows stable web_tool_tests"

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -549,20 +549,6 @@ job {
   }
 }
 job {
-  id: "Linux beta build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta build_tests"
-  }
-}
-job {
   id: "Linux beta build_tests_1_2"
   acl_sets: "prod"
   triggering_policy {
@@ -1039,20 +1025,6 @@ job {
   }
 }
 job {
-  id: "Linux beta framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta framework_tests"
-  }
-}
-job {
   id: "Linux beta framework_tests_libraries"
   acl_sets: "prod"
   triggering_policy {
@@ -1403,20 +1375,6 @@ job {
   }
 }
 job {
-  id: "Linux beta tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta tool_integration_tests"
-  }
-}
-job {
   id: "Linux beta tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -1456,20 +1414,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux beta tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Linux beta tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta tool_tests"
   }
 }
 job {
@@ -1557,20 +1501,6 @@ job {
   }
 }
 job {
-  id: "Linux beta web_long_running_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_long_running_tests"
-  }
-}
-job {
   id: "Linux beta web_long_running_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -1638,20 +1568,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux beta web_smoke_test"
-  }
-}
-job {
-  id: "Linux beta web_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_tests"
   }
 }
 job {
@@ -1792,20 +1708,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux build_aar_module_test"
-  }
-}
-job {
-  id: "Linux build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux build_tests"
   }
 }
 job {
@@ -2218,20 +2120,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev build_aar_module_test"
-  }
-}
-job {
-  id: "Linux dev build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev build_tests"
   }
 }
 job {
@@ -2711,20 +2599,6 @@ job {
   }
 }
 job {
-  id: "Linux dev framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev framework_tests"
-  }
-}
-job {
   id: "Linux dev framework_tests_libraries"
   acl_sets: "prod"
   triggering_policy {
@@ -3075,20 +2949,6 @@ job {
   }
 }
 job {
-  id: "Linux dev tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev tool_integration_tests"
-  }
-}
-job {
   id: "Linux dev tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -3128,20 +2988,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Linux dev tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev tool_tests"
   }
 }
 job {
@@ -3229,20 +3075,6 @@ job {
   }
 }
 job {
-  id: "Linux dev web_long_running_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_long_running_tests"
-  }
-}
-job {
   id: "Linux dev web_long_running_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -3310,20 +3142,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev web_smoke_test"
-  }
-}
-job {
-  id: "Linux dev web_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_tests"
   }
 }
 job {
@@ -3771,20 +3589,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux frame_policy_delay_test_android"
-  }
-}
-job {
-  id: "Linux framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux framework_tests"
   }
 }
 job {
@@ -4367,20 +4171,6 @@ job {
   }
 }
 job {
-  id: "Linux stable build_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable build_tests"
-  }
-}
-job {
   id: "Linux stable build_tests_1_2"
   acl_sets: "prod"
   triggering_policy {
@@ -4870,20 +4660,6 @@ job {
   }
 }
 job {
-  id: "Linux stable framework_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable framework_tests"
-  }
-}
-job {
   id: "Linux stable framework_tests_libraries"
   acl_sets: "prod"
   triggering_policy {
@@ -5234,20 +5010,6 @@ job {
   }
 }
 job {
-  id: "Linux stable tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable tool_integration_tests"
-  }
-}
-job {
   id: "Linux stable tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -5287,20 +5049,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux stable tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Linux stable tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable tool_tests"
   }
 }
 job {
@@ -5388,20 +5136,6 @@ job {
   }
 }
 job {
-  id: "Linux stable web_long_running_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_long_running_tests"
-  }
-}
-job {
   id: "Linux stable web_long_running_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -5469,20 +5203,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux stable web_smoke_test"
-  }
-}
-job {
-  id: "Linux stable web_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_tests"
   }
 }
 job {
@@ -5640,20 +5360,6 @@ job {
   }
 }
 job {
-  id: "Linux tool_integration_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux tool_integration_tests"
-  }
-}
-job {
   id: "Linux tool_integration_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -5693,20 +5399,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux tool_integration_tests_3_3"
-  }
-}
-job {
-  id: "Linux tool_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux tool_tests"
   }
 }
 job {
@@ -5794,20 +5486,6 @@ job {
   }
 }
 job {
-  id: "Linux web_long_running_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_long_running_tests"
-  }
-}
-job {
   id: "Linux web_long_running_tests_1_3"
   acl_sets: "prod"
   triggering_policy {
@@ -5875,20 +5553,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux web_smoke_test"
-  }
-}
-job {
-  id: "Linux web_tests"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_tests"
   }
 }
 job {
@@ -15608,32 +15272,26 @@ trigger {
   id: "beta-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux beta analyze"
-  triggers: "Linux beta build_tests"
   triggers: "Linux beta build_tests_1_2"
   triggers: "Linux beta build_tests_2_2"
   triggers: "Linux beta customer_testing"
   triggers: "Linux beta docs_test"
   triggers: "Linux beta flutter_plugins"
-  triggers: "Linux beta framework_tests"
   triggers: "Linux beta framework_tests_libraries"
   triggers: "Linux beta framework_tests_misc"
   triggers: "Linux beta framework_tests_widgets"
   triggers: "Linux beta fuchsia_precache"
-  triggers: "Linux beta tool_integration_tests"
   triggers: "Linux beta tool_integration_tests_1_3"
   triggers: "Linux beta tool_integration_tests_2_3"
   triggers: "Linux beta tool_integration_tests_3_3"
-  triggers: "Linux beta tool_tests"
   triggers: "Linux beta tool_tests_commands"
   triggers: "Linux beta tool_tests_general"
   triggers: "Linux beta web_e2e_test"
   triggers: "Linux beta web_integration_tests"
-  triggers: "Linux beta web_long_running_tests"
   triggers: "Linux beta web_long_running_tests_1_3"
   triggers: "Linux beta web_long_running_tests_2_3"
   triggers: "Linux beta web_long_running_tests_3_3"
   triggers: "Linux beta web_smoke_test"
-  triggers: "Linux beta web_tests"
   triggers: "Linux beta web_tests_0"
   triggers: "Linux beta web_tests_1"
   triggers: "Linux beta web_tests_2"
@@ -15902,32 +15560,26 @@ trigger {
   id: "dev-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux dev analyze"
-  triggers: "Linux dev build_tests"
   triggers: "Linux dev build_tests_1_2"
   triggers: "Linux dev build_tests_2_2"
   triggers: "Linux dev customer_testing"
   triggers: "Linux dev docs_test"
   triggers: "Linux dev flutter_plugins"
-  triggers: "Linux dev framework_tests"
   triggers: "Linux dev framework_tests_libraries"
   triggers: "Linux dev framework_tests_misc"
   triggers: "Linux dev framework_tests_widgets"
   triggers: "Linux dev fuchsia_precache"
-  triggers: "Linux dev tool_integration_tests"
   triggers: "Linux dev tool_integration_tests_1_3"
   triggers: "Linux dev tool_integration_tests_2_3"
   triggers: "Linux dev tool_integration_tests_3_3"
-  triggers: "Linux dev tool_tests"
   triggers: "Linux dev tool_tests_commands"
   triggers: "Linux dev tool_tests_general"
   triggers: "Linux dev web_e2e_test"
   triggers: "Linux dev web_integration_tests"
-  triggers: "Linux dev web_long_running_tests"
   triggers: "Linux dev web_long_running_tests_1_3"
   triggers: "Linux dev web_long_running_tests_2_3"
   triggers: "Linux dev web_long_running_tests_3_3"
   triggers: "Linux dev web_smoke_test"
-  triggers: "Linux dev web_tests"
   triggers: "Linux dev web_tests_0"
   triggers: "Linux dev web_tests_1"
   triggers: "Linux dev web_tests_2"
@@ -16366,32 +16018,26 @@ trigger {
   id: "master-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux analyze"
-  triggers: "Linux build_tests"
   triggers: "Linux build_tests_1_2"
   triggers: "Linux build_tests_2_2"
   triggers: "Linux customer_testing"
   triggers: "Linux docs_test"
   triggers: "Linux flutter_plugins"
-  triggers: "Linux framework_tests"
   triggers: "Linux framework_tests_libraries"
   triggers: "Linux framework_tests_misc"
   triggers: "Linux framework_tests_widgets"
   triggers: "Linux fuchsia_precache"
-  triggers: "Linux tool_integration_tests"
   triggers: "Linux tool_integration_tests_1_3"
   triggers: "Linux tool_integration_tests_2_3"
   triggers: "Linux tool_integration_tests_3_3"
-  triggers: "Linux tool_tests"
   triggers: "Linux tool_tests_commands"
   triggers: "Linux tool_tests_general"
   triggers: "Linux web_e2e_test"
   triggers: "Linux web_integration_tests"
-  triggers: "Linux web_long_running_tests"
   triggers: "Linux web_long_running_tests_1_3"
   triggers: "Linux web_long_running_tests_2_3"
   triggers: "Linux web_long_running_tests_3_3"
   triggers: "Linux web_smoke_test"
-  triggers: "Linux web_tests"
   triggers: "Linux web_tests_0"
   triggers: "Linux web_tests_1"
   triggers: "Linux web_tests_2"
@@ -16667,32 +16313,26 @@ trigger {
   id: "stable-gitiles-trigger-framework"
   acl_sets: "prod"
   triggers: "Linux stable analyze"
-  triggers: "Linux stable build_tests"
   triggers: "Linux stable build_tests_1_2"
   triggers: "Linux stable build_tests_2_2"
   triggers: "Linux stable customer_testing"
   triggers: "Linux stable docs_test"
   triggers: "Linux stable flutter_plugins"
-  triggers: "Linux stable framework_tests"
   triggers: "Linux stable framework_tests_libraries"
   triggers: "Linux stable framework_tests_misc"
   triggers: "Linux stable framework_tests_widgets"
   triggers: "Linux stable fuchsia_precache"
-  triggers: "Linux stable tool_integration_tests"
   triggers: "Linux stable tool_integration_tests_1_3"
   triggers: "Linux stable tool_integration_tests_2_3"
   triggers: "Linux stable tool_integration_tests_3_3"
-  triggers: "Linux stable tool_tests"
   triggers: "Linux stable tool_tests_commands"
   triggers: "Linux stable tool_tests_general"
   triggers: "Linux stable web_e2e_test"
   triggers: "Linux stable web_integration_tests"
-  triggers: "Linux stable web_long_running_tests"
   triggers: "Linux stable web_long_running_tests_1_3"
   triggers: "Linux stable web_long_running_tests_2_3"
   triggers: "Linux stable web_long_running_tests_3_3"
   triggers: "Linux stable web_smoke_test"
-  triggers: "Linux stable web_tests"
   triggers: "Linux stable web_tests_0"
   triggers: "Linux stable web_tests_1"
   triggers: "Linux stable web_tests_2"


### PR DESCRIPTION
This is a final step to clean up old consolidated shard builders: separated builders for each shard have been running in both try and prod for Linux, Mac and Windows.

Related issue: https://github.com/flutter/flutter/issues/77947