### PR TITLE
add todo to remove devicelab builders after stable release

### DIFF
--- a/config/devicelab_config.star
+++ b/config/devicelab_config.star
@@ -1246,6 +1246,8 @@ def devicelab_try_config():
         caches = LINUX_DEFAULT_CACHES,
         os = LINUX_OS,
     )
+    # TODO(fujino): remove once https://github.com/flutter/flutter/pull/80161
+    # rolls to stable
     common.linux_try_builder(
         name = "Linux gradle_non_android_plugin_test|gnap",
         recipe = drone_recipe_name,
@@ -1428,6 +1430,8 @@ def devicelab_try_config():
         dimensions = {"device_type": "none"},
         os = MAC_OS,
     )
+    # TODO(fujino): remove once https://github.com/flutter/flutter/pull/80161
+    # rolls to stable
     common.mac_try_builder(
         name = "Mac gradle_non_android_plugin_test|gnap",
         recipe = drone_recipe_name,
@@ -1799,6 +1803,8 @@ def devicelab_try_config():
         caches = WIN_DEFAULT_CACHES,
         os = "Windows-Server",
     )
+    # TODO(fujino): remove once https://github.com/flutter/flutter/pull/80161
+    # rolls to stable
     common.windows_try_builder(
         name = "Windows gradle_non_android_plugin_test|gnap",
         recipe = drone_recipe_name,


### PR DESCRIPTION
This test file was migrated to a tools_test in https://github.com/flutter/flutter/pull/80161