### PR TITLE
Add cores dimension to the correct place.

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -268,7 +268,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = LINUX_OS,
         bucket = "prod",
         branch_name = "" if branch == "master" else " " + branch,
-        dimensions = {"cores": "12"},
     )
     common.linux_prod_builder(
         name = "Linux%s web_tool_tests|web_tt" % ("" if branch == "master" else " " + branch),
@@ -695,7 +694,7 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
             },
             "use_cas": True,
         },
-        dimensions = {"device_type": "none"},
+        dimensions = {"device_type": "none", "cores": "12"},
         caches = MAC_DEFAULT_CACHES,
         os = MAC_OS,
         bucket = "prod",

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -3497,7 +3497,6 @@ buckets {
     builders {
       name: "Linux beta tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -3535,7 +3534,6 @@ buckets {
     builders {
       name: "Linux beta tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -3573,7 +3571,6 @@ buckets {
     builders {
       name: "Linux beta tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -3611,7 +3608,6 @@ buckets {
     builders {
       name: "Linux beta tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -7674,7 +7670,6 @@ buckets {
     builders {
       name: "Linux dev tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -7712,7 +7707,6 @@ buckets {
     builders {
       name: "Linux dev tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -7750,7 +7744,6 @@ buckets {
     builders {
       name: "Linux dev tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -7788,7 +7781,6 @@ buckets {
     builders {
       name: "Linux dev tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -13211,7 +13203,6 @@ buckets {
     builders {
       name: "Linux stable tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -13249,7 +13240,6 @@ buckets {
     builders {
       name: "Linux stable tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -13287,7 +13277,6 @@ buckets {
     builders {
       name: "Linux stable tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -13325,7 +13314,6 @@ buckets {
     builders {
       name: "Linux stable tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -14213,7 +14201,6 @@ buckets {
     builders {
       name: "Linux tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -14251,7 +14238,6 @@ buckets {
     builders {
       name: "Linux tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -14289,7 +14275,6 @@ buckets {
     builders {
       name: "Linux tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -14327,7 +14312,6 @@ buckets {
     builders {
       name: "Linux tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "cores:12"
       dimensions: "os:Linux"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -16733,6 +16717,7 @@ buckets {
     builders {
       name: "Mac beta tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -16779,6 +16764,7 @@ buckets {
     builders {
       name: "Mac beta tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -16825,6 +16811,7 @@ buckets {
     builders {
       name: "Mac beta tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -16871,6 +16858,7 @@ buckets {
     builders {
       name: "Mac beta tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -18636,6 +18624,7 @@ buckets {
     builders {
       name: "Mac dev tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -18682,6 +18671,7 @@ buckets {
     builders {
       name: "Mac dev tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -18728,6 +18718,7 @@ buckets {
     builders {
       name: "Mac dev tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -18774,6 +18765,7 @@ buckets {
     builders {
       name: "Mac dev tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -20839,6 +20831,7 @@ buckets {
     builders {
       name: "Mac stable tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -20885,6 +20878,7 @@ buckets {
     builders {
       name: "Mac stable tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -20931,6 +20925,7 @@ buckets {
     builders {
       name: "Mac stable tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -20977,6 +20972,7 @@ buckets {
     builders {
       name: "Mac stable tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -21182,6 +21178,7 @@ buckets {
     builders {
       name: "Mac tool_integration_tests_1_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -21228,6 +21225,7 @@ buckets {
     builders {
       name: "Mac tool_integration_tests_2_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -21274,6 +21272,7 @@ buckets {
     builders {
       name: "Mac tool_integration_tests_3_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"
@@ -21320,6 +21319,7 @@ buckets {
     builders {
       name: "Mac tool_integration_tests_4_4"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "cores:12"
       dimensions: "device_type:none"
       dimensions: "os:Mac-10.15"
       dimensions: "pool:luci.flutter.prod"


### PR DESCRIPTION
The previous PR added the dimension to the linux bots rather than the
mac ones.

Bug: https://github.com/flutter/flutter/issues/81793