### PR TITLE
Add device_type: none dimension to engine prod windows builders

### DIFF
--- a/config/engine_config.star
+++ b/config/engine_config.star
@@ -293,6 +293,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"device_type": "none"},
         **platform_args["windows"]
     )
     common.linux_prod_builder(
@@ -501,6 +502,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"device_type": "none"},
         **platform_args["windows"]
     )
     common.windows_prod_builder(
@@ -511,6 +513,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"device_type": "none"},
         **platform_args["windows"]
     )
     common.windows_prod_builder(
@@ -521,6 +524,7 @@ def engine_prod_config(platform_args, branch, version, ref, fuchsia_ctl_version)
         triggered_by = [trigger_name],
         triggering_policy = triggering_policy,
         priority = 30 if branch == "master" else 25,
+        dimensions = {"device_type": "none"},
         **platform_args["windows"]
     )
     common.windows_prod_builder(

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -37996,6 +37996,7 @@ buckets {
     builders {
       name: "Windows Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38081,6 +38082,7 @@ buckets {
     builders {
       name: "Windows Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38134,6 +38136,7 @@ buckets {
     builders {
       name: "Windows UWP Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38151,6 +38154,7 @@ buckets {
     builders {
       name: "Windows Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38168,6 +38172,7 @@ buckets {
     builders {
       name: "Windows beta Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38202,6 +38207,7 @@ buckets {
     builders {
       name: "Windows beta Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38255,6 +38261,7 @@ buckets {
     builders {
       name: "Windows beta UWP Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -38272,6 +38279,7 @@ buckets {
     builders {
       name: "Windows beta Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -39362,6 +39370,7 @@ buckets {
     builders {
       name: "Windows dev Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -39396,6 +39405,7 @@ buckets {
     builders {
       name: "Windows dev Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -39449,6 +39459,7 @@ buckets {
     builders {
       name: "Windows dev UWP Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -39466,6 +39477,7 @@ buckets {
     builders {
       name: "Windows dev Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -40815,6 +40827,7 @@ buckets {
     builders {
       name: "Windows stable Android AOT Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -40849,6 +40862,7 @@ buckets {
     builders {
       name: "Windows stable Host Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -40902,6 +40916,7 @@ buckets {
     builders {
       name: "Windows stable UWP Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {
@@ -40919,6 +40934,7 @@ buckets {
     builders {
       name: "Windows stable Web Engine"
       swarming_host: "chromium-swarm.appspot.com"
+      dimensions: "device_type:none"
       dimensions: "os:Windows-10"
       dimensions: "pool:luci.flutter.prod"
       exe {


### PR DESCRIPTION
Engine builds are scheduled on DeviceLab windows bots:
https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20UWP%20Engine/334/overview, causing build failures.

This PR enforce `device_type: none` dimension.

Related: https://github.com/flutter/flutter/issues/82217