### PR TITLE
remove web e2e and smoke test builders

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -431,38 +431,6 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         os = LINUX_OS,
     )
     common.linux_prod_builder(
-        name = "Linux%s web_e2e_test|web_e2e" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "validation": "web_e2e_test",
-            "validation_name": "Web e2e tests",
-            "dependencies": [{"dependency": "chrome_and_driver"}, {"dependency": "curl"}],
-            "use_cas": True,
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-    common.linux_prod_builder(
-        name = "Linux%s web_smoke_test|web_smk" % ("" if branch == "master" else " " + branch),
-        recipe = new_recipe_name,
-        console_view_name = console_view_name,
-        triggered_by = [trigger_name],
-        triggering_policy = triggering_policy,
-        priority = priority,
-        properties = {
-            "validation": "web_smoke_test",
-            "validation_name": "Web smoke tests",
-            "dependencies": [{"dependency": "chrome_and_driver"}, {"dependency": "curl"}],
-            "use_cas": True,
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-    common.linux_prod_builder(
         name = "Linux%s flutter_plugins|fltplgns" % ("" if branch == "master" else " " + branch),
         recipe = drone_recipe_name,
         console_view_name = console_view_name,
@@ -997,34 +965,6 @@ def framework_try_config():
             "validation": "fuchsia_precache",
             "validation_name": "Fuchsia precache",
             "dependencies": [{"dependency": "curl"}],
-            "use_cas": True,
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-    common.linux_try_builder(
-        name = "Linux web_e2e_test|web_e2e",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "validation": "web_e2e_test",
-            "validation_name": "Web e2e tests",
-            "dependencies": [{"dependency": "chrome_and_driver"}, {"dependency": "curl"}],
-            "use_cas": True,
-        },
-        caches = LINUX_DEFAULT_CACHES,
-        os = LINUX_OS,
-    )
-    common.linux_try_builder(
-        name = "Linux web_smoke_test|web_smk",
-        recipe = "flutter/flutter",
-        repo = repos.FLUTTER,
-        list_view_name = list_view_name,
-        properties = {
-            "validation": "web_smoke_test",
-            "validation_name": "Web smoke tests",
-            "dependencies": [{"dependency": "chrome_and_driver"}, {"dependency": "curl"}],
             "use_cas": True,
         },
         caches = LINUX_DEFAULT_CACHES,

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -3866,43 +3866,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta web_e2e_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_2_2_0\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_e2e_test\",\"validation_name\":\"Web e2e tests\"}"
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -4061,43 +4024,6 @@ buckets {
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"devicelab/devicelab_drone_2_2_0\",\"task_name\":\"web_size__compile_test\",\"upload_metrics\":false,\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 1800
       expiration_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux beta web_smoke_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_2_2_0\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_smoke_test\",\"validation_name\":\"Web smoke tests\"}"
-      priority: 29
-      execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
         path: "android"
@@ -8077,43 +8003,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux dev web_e2e_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_e2e_test\",\"validation_name\":\"Web e2e tests\"}"
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux dev web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -8272,43 +8161,6 @@ buckets {
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"devicelab/devicelab_drone\",\"task_name\":\"web_size__compile_test\",\"upload_metrics\":false,\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 1800
       expiration_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux dev web_smoke_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_smoke_test\",\"validation_name\":\"Web smoke tests\"}"
-      priority: 29
-      execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
         path: "android"
@@ -13686,43 +13538,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable web_e2e_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_1_26_0\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_e2e_test\",\"validation_name\":\"Web e2e tests\"}"
-      priority: 29
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -13881,43 +13696,6 @@ buckets {
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"devicelab/devicelab_drone_1_26_0\",\"task_name\":\"web_size__compile_test\",\"upload_metrics\":false,\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 1800
       expiration_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux stable web_smoke_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_1_26_0\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_smoke_test\",\"validation_name\":\"Web smoke tests\"}"
-      priority: 29
-      execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
         path: "android"
@@ -14684,43 +14462,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_e2e_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_e2e_test\",\"validation_name\":\"Web e2e tests\"}"
-      priority: 30
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -14879,43 +14620,6 @@ buckets {
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"devicelab/devicelab_drone\",\"task_name\":\"web_size__compile_test\",\"upload_metrics\":true,\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 1800
       expiration_secs: 10800
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux web_smoke_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter\",\"upload_packages\":true,\"use_cas\":true,\"validation\":\"web_smoke_test\",\"validation_name\":\"Web smoke tests\"}"
-      priority: 30
-      execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
         path: "android"
@@ -44960,42 +44664,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_e2e_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter\",\"upload_packages\":false,\"use_cas\":true,\"validation\":\"web_e2e_test\",\"validation_name\":\"Web e2e tests\"}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_integration_tests"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -45114,42 +44782,6 @@ buckets {
         cmd: "luciexe"
       }
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"3_3\",\"upload_packages\":false,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux web_smoke_test"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter\",\"upload_packages\":false,\"use_cas\":true,\"validation\":\"web_smoke_test\",\"validation_name\":\"Web smoke tests\"}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -4767,16 +4767,6 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_e2e_test"
-    category: "Linux"
-    short_name: "web_e2e"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable flutter_plugins"
     category: "Linux"
     short_name: "fltplgns"
@@ -5088,16 +5078,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta fuchsia_precache"
     category: "Linux"
     short_name: "pcache"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_e2e_test"
-    category: "Linux"
-    short_name: "web_e2e"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta flutter_plugins"
@@ -5413,16 +5393,6 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_e2e_test"
-    category: "Linux"
-    short_name: "web_e2e"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev flutter_plugins"
     category: "Linux"
     short_name: "fltplgns"
@@ -5731,16 +5701,6 @@ consoles {
     short_name: "pcache"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_e2e_test"
-    category: "Linux"
-    short_name: "web_e2e"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_smoke_test"
-    category: "Linux"
-    short_name: "web_smk"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux flutter_plugins"
     category: "Linux"
     short_name: "fltplgns"
@@ -6000,12 +5960,6 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux fuchsia_precache"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux web_e2e_test"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux web_smoke_test"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Mac build_tests_1_4"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -1221,17 +1221,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta web_e2e_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta web_integration_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1277,17 +1266,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux beta web_size__compile_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux beta web_smoke_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2486,17 +2464,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux dev web_e2e_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux dev web_integration_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2542,17 +2509,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux dev web_size__compile_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux dev web_smoke_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4169,17 +4125,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable web_e2e_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable web_integration_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4225,17 +4170,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux stable web_size__compile_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux stable web_smoke_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4466,17 +4400,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux web_e2e_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux web_integration_tests"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4522,17 +4445,6 @@ notifiers {
   builders {
     bucket: "prod"
     name: "Linux web_size__compile_test"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux web_smoke_test"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -1529,20 +1529,6 @@ job {
   }
 }
 job {
-  id: "Linux beta web_e2e_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_e2e_test"
-  }
-}
-job {
   id: "Linux beta web_integration_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -1610,20 +1596,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux beta web_size__compile_test"
-  }
-}
-job {
-  id: "Linux beta web_smoke_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_smoke_test"
   }
 }
 job {
@@ -3131,20 +3103,6 @@ job {
   }
 }
 job {
-  id: "Linux dev web_e2e_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_e2e_test"
-  }
-}
-job {
   id: "Linux dev web_integration_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -3212,20 +3170,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev web_size__compile_test"
-  }
-}
-job {
-  id: "Linux dev web_smoke_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_smoke_test"
   }
 }
 job {
@@ -5262,20 +5206,6 @@ job {
   }
 }
 job {
-  id: "Linux stable web_e2e_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_e2e_test"
-  }
-}
-job {
   id: "Linux stable web_integration_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -5343,20 +5273,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux stable web_size__compile_test"
-  }
-}
-job {
-  id: "Linux stable web_smoke_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_smoke_test"
   }
 }
 job {
@@ -5640,20 +5556,6 @@ job {
   }
 }
 job {
-  id: "Linux web_e2e_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_e2e_test"
-  }
-}
-job {
   id: "Linux web_integration_tests"
   acl_sets: "prod"
   triggering_policy {
@@ -5721,20 +5623,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux web_size__compile_test"
-  }
-}
-job {
-  id: "Linux web_smoke_test"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_smoke_test"
   }
 }
 job {
@@ -15941,12 +15829,10 @@ trigger {
   triggers: "Linux beta tool_tests_commands"
   triggers: "Linux beta tool_tests_general"
   triggers: "Linux beta validate_ci_config"
-  triggers: "Linux beta web_e2e_test"
   triggers: "Linux beta web_integration_tests"
   triggers: "Linux beta web_long_running_tests_1_3"
   triggers: "Linux beta web_long_running_tests_2_3"
   triggers: "Linux beta web_long_running_tests_3_3"
-  triggers: "Linux beta web_smoke_test"
   triggers: "Linux beta web_tests_0"
   triggers: "Linux beta web_tests_1"
   triggers: "Linux beta web_tests_2"
@@ -16238,12 +16124,10 @@ trigger {
   triggers: "Linux dev tool_tests_commands"
   triggers: "Linux dev tool_tests_general"
   triggers: "Linux dev validate_ci_config"
-  triggers: "Linux dev web_e2e_test"
   triggers: "Linux dev web_integration_tests"
   triggers: "Linux dev web_long_running_tests_1_3"
   triggers: "Linux dev web_long_running_tests_2_3"
   triggers: "Linux dev web_long_running_tests_3_3"
-  triggers: "Linux dev web_smoke_test"
   triggers: "Linux dev web_tests_0"
   triggers: "Linux dev web_tests_1"
   triggers: "Linux dev web_tests_2"
@@ -16715,12 +16599,10 @@ trigger {
   triggers: "Linux tool_tests_commands"
   triggers: "Linux tool_tests_general"
   triggers: "Linux validate_ci_config"
-  triggers: "Linux web_e2e_test"
   triggers: "Linux web_integration_tests"
   triggers: "Linux web_long_running_tests_1_3"
   triggers: "Linux web_long_running_tests_2_3"
   triggers: "Linux web_long_running_tests_3_3"
-  triggers: "Linux web_smoke_test"
   triggers: "Linux web_tests_0"
   triggers: "Linux web_tests_1"
   triggers: "Linux web_tests_2"
@@ -17019,12 +16901,10 @@ trigger {
   triggers: "Linux stable tool_tests_commands"
   triggers: "Linux stable tool_tests_general"
   triggers: "Linux stable validate_ci_config"
-  triggers: "Linux stable web_e2e_test"
   triggers: "Linux stable web_integration_tests"
   triggers: "Linux stable web_long_running_tests_1_3"
   triggers: "Linux stable web_long_running_tests_2_3"
   triggers: "Linux stable web_long_running_tests_3_3"
-  triggers: "Linux stable web_smoke_test"
   triggers: "Linux stable web_tests_0"
   triggers: "Linux stable web_tests_1"
   triggers: "Linux stable web_tests_2"


### PR DESCRIPTION
They have been rolled under the web_long_running_tests shard.