### PR TITLE
remove old web_long_running_tests shards

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -311,7 +311,7 @@ def framework_prod_config(branch, version, testing_ref, release_ref):
         triggering_policy = triggering_policy,
         properties = {
             "shard": "web_long_running_tests",
-            "subshards": ["1_3", "2_3", "3_3", "1_5", "2_5", "3_5", "4_5", "5_5"],
+            "subshards": ["1_5", "2_5", "3_5", "4_5", "5_5"],
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
             "use_cas": True,
         },
@@ -823,7 +823,7 @@ def framework_try_config():
         list_view_name = list_view_name,
         properties = {
             "shard": "web_long_running_tests",
-            "subshards": ["1_3", "2_3", "3_3", "1_5", "2_5", "3_5", "4_5", "5_5"],
+            "subshards": ["1_5", "2_5", "3_5", "4_5", "5_5"],
             "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "goldctl"}, {"dependency": "curl"}],
             "use_cas": True,
         },

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -3866,42 +3866,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta web_long_running_tests_1_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_2_2_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"1_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta web_long_running_tests_1_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -3938,42 +3902,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux beta web_long_running_tests_2_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_2_2_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux beta web_long_running_tests_2_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -3984,42 +3912,6 @@ buckets {
         cmd: "luciexe"
       }
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_2_2_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_5\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux beta web_long_running_tests_3_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_2_2_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"3_3\",\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -8146,42 +8038,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux dev web_long_running_tests_1_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"1_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux dev web_long_running_tests_1_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -8218,42 +8074,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux dev web_long_running_tests_2_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux dev web_long_running_tests_2_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -8264,42 +8084,6 @@ buckets {
         cmd: "luciexe"
       }
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_5\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux dev web_long_running_tests_3_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"3_3\",\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -13824,42 +13608,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable web_long_running_tests_1_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_1_26_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"1_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable web_long_running_tests_1_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -13896,42 +13644,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux stable web_long_running_tests_2_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_1_26_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux stable web_long_running_tests_2_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -13942,42 +13654,6 @@ buckets {
         cmd: "luciexe"
       }
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_1_26_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_5\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux stable web_long_running_tests_3_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone_1_26_0\",\"shard\":\"web_long_running_tests\",\"subshard\":\"3_3\",\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -14891,42 +14567,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_long_running_tests_1_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"1_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_long_running_tests_1_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -14963,42 +14603,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_long_running_tests_2_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_3\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_long_running_tests_2_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -15009,42 +14613,6 @@ buckets {
         cmd: "luciexe"
       }
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_5\",\"upload_packages\":true,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux web_long_running_tests_3_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.prod"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":false,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"3_3\",\"upload_packages\":true,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -45236,42 +44804,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_long_running_tests_1_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"1_3\",\"upload_packages\":false,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_long_running_tests_1_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -45308,42 +44840,6 @@ buckets {
       task_template_canary_percentage {}
     }
     builders {
-      name: "Linux web_long_running_tests_2_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_3\",\"upload_packages\":false,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
       name: "Linux web_long_running_tests_2_5"
       swarming_host: "chromium-swarm.appspot.com"
       dimensions: "os:Linux"
@@ -45354,42 +44850,6 @@ buckets {
         cmd: "luciexe"
       }
       properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"2_5\",\"upload_packages\":false,\"use_cas\":true}"
-      execution_timeout_secs: 3600
-      caches {
-        name: "android_sdk"
-        path: "android"
-      }
-      caches {
-        name: "chrome_and_driver"
-        path: "chrome"
-      }
-      caches {
-        name: "flutter_sdk"
-        path: "flutter sdk"
-      }
-      caches {
-        name: "openjdk"
-        path: "java"
-      }
-      caches {
-        name: "pub_cache"
-        path: ".pub-cache"
-      }
-      build_numbers: YES
-      service_account: "flutter-try-builder@chops-service-accounts.iam.gserviceaccount.com"
-      task_template_canary_percentage {}
-    }
-    builders {
-      name: "Linux web_long_running_tests_3_3"
-      swarming_host: "chromium-swarm.appspot.com"
-      dimensions: "os:Linux"
-      dimensions: "pool:luci.flutter.try"
-      exe {
-        cipd_package: "flutter/recipe_bundles/flutter.googlesource.com/recipes"
-        cipd_version: "refs/heads/master"
-        cmd: "luciexe"
-      }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"curl\"}],\"fuchsia_ctl_version\":\"version:0.0.23\",\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"web_long_running_tests\",\"subshard\":\"3_3\",\"upload_packages\":false,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"

--- a/config/generated/flutter/luci/luci-milo.cfg
+++ b/config/generated/flutter/luci/luci-milo.cfg
@@ -4722,21 +4722,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests_1_3"
-    category: "Linux"
-    short_name: "wlrt1"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests_2_3"
-    category: "Linux"
-    short_name: "wlrt2"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests_3_3"
-    category: "Linux"
-    short_name: "wlrt3"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux stable web_long_running_tests_1_5"
     category: "Linux"
     short_name: "wlrt1"
@@ -5053,21 +5038,6 @@ consoles {
     name: "buildbucket/luci.flutter.prod/Linux beta web_tests_7_last"
     category: "Linux"
     short_name: "wt7l"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests_1_3"
-    category: "Linux"
-    short_name: "wlrt1"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests_2_3"
-    category: "Linux"
-    short_name: "wlrt2"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests_3_3"
-    category: "Linux"
-    short_name: "wlrt3"
   }
   builders {
     name: "buildbucket/luci.flutter.prod/Linux beta web_long_running_tests_1_5"
@@ -5388,21 +5358,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests_1_3"
-    category: "Linux"
-    short_name: "wlrt1"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests_2_3"
-    category: "Linux"
-    short_name: "wlrt2"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests_3_3"
-    category: "Linux"
-    short_name: "wlrt3"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux dev web_long_running_tests_1_5"
     category: "Linux"
     short_name: "wlrt1"
@@ -5716,21 +5671,6 @@ consoles {
     short_name: "wt7l"
   }
   builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests_1_3"
-    category: "Linux"
-    short_name: "wlrt1"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests_2_3"
-    category: "Linux"
-    short_name: "wlrt2"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests_3_3"
-    category: "Linux"
-    short_name: "wlrt3"
-  }
-  builders {
     name: "buildbucket/luci.flutter.prod/Linux web_long_running_tests_1_5"
     category: "Linux"
     short_name: "wlrt1"
@@ -6004,15 +5944,6 @@ consoles {
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_tests_7_last"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux web_long_running_tests_1_3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux web_long_running_tests_2_3"
-  }
-  builders {
-    name: "buildbucket/luci.flutter.try/Linux web_long_running_tests_3_3"
   }
   builders {
     name: "buildbucket/luci.flutter.try/Linux web_long_running_tests_1_5"

--- a/config/generated/flutter/luci/luci-notify.cfg
+++ b/config/generated/flutter/luci/luci-notify.cfg
@@ -1221,17 +1221,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta web_long_running_tests_1_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta web_long_running_tests_1_5"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -1243,29 +1232,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux beta web_long_running_tests_2_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux beta web_long_running_tests_2_5"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux beta web_long_running_tests_3_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -2508,17 +2475,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux dev web_long_running_tests_1_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux dev web_long_running_tests_1_5"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -2530,29 +2486,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux dev web_long_running_tests_2_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux dev web_long_running_tests_2_5"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux dev web_long_running_tests_3_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4213,17 +4147,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable web_long_running_tests_1_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable web_long_running_tests_1_5"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4235,29 +4158,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux stable web_long_running_tests_2_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux stable web_long_running_tests_2_5"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux stable web_long_running_tests_3_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }
@@ -4532,17 +4433,6 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux web_long_running_tests_1_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux web_long_running_tests_1_5"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
@@ -4554,29 +4444,7 @@ notifiers {
   }
   builders {
     bucket: "prod"
-    name: "Linux web_long_running_tests_2_3"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
     name: "Linux web_long_running_tests_2_5"
-    repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
-  }
-}
-notifiers {
-  notifications {
-    on_new_failure: true
-    notify_blamelist {}
-  }
-  builders {
-    bucket: "prod"
-    name: "Linux web_long_running_tests_3_3"
     repository: "https://chromium.googlesource.com/external/github.com/flutter/flutter"
   }
 }

--- a/config/generated/flutter/luci/luci-scheduler.cfg
+++ b/config/generated/flutter/luci/luci-scheduler.cfg
@@ -1529,20 +1529,6 @@ job {
   }
 }
 job {
-  id: "Linux beta web_long_running_tests_1_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_long_running_tests_1_3"
-  }
-}
-job {
   id: "Linux beta web_long_running_tests_1_5"
   acl_sets: "prod"
   triggering_policy {
@@ -1557,20 +1543,6 @@ job {
   }
 }
 job {
-  id: "Linux beta web_long_running_tests_2_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_long_running_tests_2_3"
-  }
-}
-job {
   id: "Linux beta web_long_running_tests_2_5"
   acl_sets: "prod"
   triggering_policy {
@@ -1582,20 +1554,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux beta web_long_running_tests_2_5"
-  }
-}
-job {
-  id: "Linux beta web_long_running_tests_3_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux beta web_long_running_tests_3_3"
   }
 }
 job {
@@ -3159,20 +3117,6 @@ job {
   }
 }
 job {
-  id: "Linux dev web_long_running_tests_1_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_long_running_tests_1_3"
-  }
-}
-job {
   id: "Linux dev web_long_running_tests_1_5"
   acl_sets: "prod"
   triggering_policy {
@@ -3187,20 +3131,6 @@ job {
   }
 }
 job {
-  id: "Linux dev web_long_running_tests_2_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_long_running_tests_2_3"
-  }
-}
-job {
   id: "Linux dev web_long_running_tests_2_5"
   acl_sets: "prod"
   triggering_policy {
@@ -3212,20 +3142,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux dev web_long_running_tests_2_5"
-  }
-}
-job {
-  id: "Linux dev web_long_running_tests_3_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux dev web_long_running_tests_3_3"
   }
 }
 job {
@@ -5318,20 +5234,6 @@ job {
   }
 }
 job {
-  id: "Linux stable web_long_running_tests_1_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_long_running_tests_1_3"
-  }
-}
-job {
   id: "Linux stable web_long_running_tests_1_5"
   acl_sets: "prod"
   triggering_policy {
@@ -5346,20 +5248,6 @@ job {
   }
 }
 job {
-  id: "Linux stable web_long_running_tests_2_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_long_running_tests_2_3"
-  }
-}
-job {
   id: "Linux stable web_long_running_tests_2_5"
   acl_sets: "prod"
   triggering_policy {
@@ -5371,20 +5259,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux stable web_long_running_tests_2_5"
-  }
-}
-job {
-  id: "Linux stable web_long_running_tests_3_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 1
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux stable web_long_running_tests_3_3"
   }
 }
 job {
@@ -5724,20 +5598,6 @@ job {
   }
 }
 job {
-  id: "Linux web_long_running_tests_1_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_long_running_tests_1_3"
-  }
-}
-job {
   id: "Linux web_long_running_tests_1_5"
   acl_sets: "prod"
   triggering_policy {
@@ -5752,20 +5612,6 @@ job {
   }
 }
 job {
-  id: "Linux web_long_running_tests_2_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_long_running_tests_2_3"
-  }
-}
-job {
   id: "Linux web_long_running_tests_2_5"
   acl_sets: "prod"
   triggering_policy {
@@ -5777,20 +5623,6 @@ job {
     server: "cr-buildbucket.appspot.com"
     bucket: "luci.flutter.prod"
     builder: "Linux web_long_running_tests_2_5"
-  }
-}
-job {
-  id: "Linux web_long_running_tests_3_3"
-  acl_sets: "prod"
-  triggering_policy {
-    kind: GREEDY_BATCHING
-    max_concurrent_invocations: 3
-    max_batch_size: 3
-  }
-  buildbucket {
-    server: "cr-buildbucket.appspot.com"
-    bucket: "luci.flutter.prod"
-    builder: "Linux web_long_running_tests_3_3"
   }
 }
 job {
@@ -16053,11 +15885,8 @@ trigger {
   triggers: "Linux beta tool_tests_commands"
   triggers: "Linux beta tool_tests_general"
   triggers: "Linux beta validate_ci_config"
-  triggers: "Linux beta web_long_running_tests_1_3"
   triggers: "Linux beta web_long_running_tests_1_5"
-  triggers: "Linux beta web_long_running_tests_2_3"
   triggers: "Linux beta web_long_running_tests_2_5"
-  triggers: "Linux beta web_long_running_tests_3_3"
   triggers: "Linux beta web_long_running_tests_3_5"
   triggers: "Linux beta web_long_running_tests_4_5"
   triggers: "Linux beta web_long_running_tests_5_5"
@@ -16352,11 +16181,8 @@ trigger {
   triggers: "Linux dev tool_tests_commands"
   triggers: "Linux dev tool_tests_general"
   triggers: "Linux dev validate_ci_config"
-  triggers: "Linux dev web_long_running_tests_1_3"
   triggers: "Linux dev web_long_running_tests_1_5"
-  triggers: "Linux dev web_long_running_tests_2_3"
   triggers: "Linux dev web_long_running_tests_2_5"
-  triggers: "Linux dev web_long_running_tests_3_3"
   triggers: "Linux dev web_long_running_tests_3_5"
   triggers: "Linux dev web_long_running_tests_4_5"
   triggers: "Linux dev web_long_running_tests_5_5"
@@ -16831,11 +16657,8 @@ trigger {
   triggers: "Linux tool_tests_commands"
   triggers: "Linux tool_tests_general"
   triggers: "Linux validate_ci_config"
-  triggers: "Linux web_long_running_tests_1_3"
   triggers: "Linux web_long_running_tests_1_5"
-  triggers: "Linux web_long_running_tests_2_3"
   triggers: "Linux web_long_running_tests_2_5"
-  triggers: "Linux web_long_running_tests_3_3"
   triggers: "Linux web_long_running_tests_3_5"
   triggers: "Linux web_long_running_tests_4_5"
   triggers: "Linux web_long_running_tests_5_5"
@@ -17137,11 +16960,8 @@ trigger {
   triggers: "Linux stable tool_tests_commands"
   triggers: "Linux stable tool_tests_general"
   triggers: "Linux stable validate_ci_config"
-  triggers: "Linux stable web_long_running_tests_1_3"
   triggers: "Linux stable web_long_running_tests_1_5"
-  triggers: "Linux stable web_long_running_tests_2_3"
   triggers: "Linux stable web_long_running_tests_2_5"
-  triggers: "Linux stable web_long_running_tests_3_3"
   triggers: "Linux stable web_long_running_tests_3_5"
   triggers: "Linux stable web_long_running_tests_4_5"
   triggers: "Linux stable web_long_running_tests_5_5"


### PR DESCRIPTION
The framework doesn't use "1_3", "2_3", "3_3" any more.