### PR TITLE
Fix dependency key.

### DIFF
--- a/config/framework_config.star
+++ b/config/framework_config.star
@@ -1135,7 +1135,7 @@ def framework_try_config():
         properties = {
             "shard": "tool_integration_tests",
             "subshards": ["1_5", "2_5", "3_5", "4_5", "5_5"],
-            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}, {"dependency": "certs"}, {"dependency     ": "vs_build"}],
+            "dependencies": [{"dependency": "android_sdk"}, {"dependency": "chrome_and_driver"}, {"dependency": "open_jdk"}, {"dependency": "goldctl"}, {"dependency": "certs"}, {"dependency": "vs_build"}],
             "use_cas": True,
         },
         caches = WIN_DEFAULT_CACHES,

--- a/config/generated/flutter/luci/cr-buildbucket.cfg
+++ b/config/generated/flutter/luci/cr-buildbucket.cfg
@@ -47849,7 +47849,7 @@ buckets {
         cipd_version: "refs/heads/master"
         cmd: "luciexe"
       }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency     \":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"1_5\",\"upload_packages\":false,\"use_cas\":true}"
+      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency\":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"1_5\",\"upload_packages\":false,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -47889,7 +47889,7 @@ buckets {
         cipd_version: "refs/heads/master"
         cmd: "luciexe"
       }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency     \":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"2_5\",\"upload_packages\":false,\"use_cas\":true}"
+      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency\":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"2_5\",\"upload_packages\":false,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -47929,7 +47929,7 @@ buckets {
         cipd_version: "refs/heads/master"
         cmd: "luciexe"
       }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency     \":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"3_5\",\"upload_packages\":false,\"use_cas\":true}"
+      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency\":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"3_5\",\"upload_packages\":false,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -47969,7 +47969,7 @@ buckets {
         cipd_version: "refs/heads/master"
         cmd: "luciexe"
       }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency     \":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"4_5\",\"upload_packages\":false,\"use_cas\":true}"
+      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency\":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"4_5\",\"upload_packages\":false,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"
@@ -48009,7 +48009,7 @@ buckets {
         cipd_version: "refs/heads/master"
         cmd: "luciexe"
       }
-      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency     \":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"5_5\",\"upload_packages\":false,\"use_cas\":true}"
+      properties: "{\"$fuchsia/goma\":{\"server\":\"rbe-prod1.endpoints.fuchsia-infra-goma-prod.cloud.goog\"},\"$kitchen\":{\"emulate_gce\":true},\"$recipe_engine/isolated\":{\"server\":\"https://isolateserver.appspot.com\"},\"$recipe_engine/swarming\":{\"server\":\"https://chromium-swarm.appspot.com\"},\"clobber\":false,\"dependencies\":[{\"dependency\":\"android_sdk\"},{\"dependency\":\"chrome_and_driver\"},{\"dependency\":\"open_jdk\"},{\"dependency\":\"goldctl\"},{\"dependency\":\"certs\"},{\"dependency\":\"vs_build\"}],\"gold_tryjob\":true,\"goma_jobs\":\"200\",\"mastername\":\"client.flutter\",\"recipe\":\"flutter/flutter_drone\",\"shard\":\"tool_integration_tests\",\"subshard\":\"5_5\",\"upload_packages\":false,\"use_cas\":true}"
       execution_timeout_secs: 3600
       caches {
         name: "android_sdk"


### PR DESCRIPTION
Windows tool_integration_tests dependency key has several white spaces
at the end of the string causing the dependency installation to fail.