### PR TITLE
Revert "Temporarily disable cocoon builders in led recipe tests."

### DIFF
--- a/config/cocoon_config.star
+++ b/config/cocoon_config.star
@@ -55,6 +55,7 @@ def cocoon_try_config(platform_args):
         recipe = "cocoon/cocoon",
         list_view_name = list_view_name,
         repo = repos.COCOON,
+        add_cq = True,
         execution_timeout = timeout.SHORT,
         **platform_args["linux"]
     )
@@ -74,6 +75,7 @@ def cocoon_try_config(platform_args):
         recipe = "cocoon/device_doctor",
         list_view_name = list_view_name,
         repo = repos.COCOON,
+        add_cq = True,
         execution_timeout = timeout.SHORT,
         **platform_args["mac"]
     )
@@ -84,6 +86,7 @@ def cocoon_try_config(platform_args):
         recipe = "cocoon/device_doctor",
         list_view_name = list_view_name,
         repo = repos.COCOON,
+        add_cq = True,
         execution_timeout = timeout.SHORT,
         **platform_args["windows"]
     )

--- a/config/generated/flutter/luci/commit-queue.cfg
+++ b/config/generated/flutter/luci/commit-queue.cfg
@@ -20,7 +20,16 @@ config_groups {
     }
     tryjob {
       builders {
+        name: "flutter/try/Cocoon"
+      }
+      builders {
         name: "flutter/try/Linux device_doctor"
+      }
+      builders {
+        name: "flutter/try/Mac device_doctor"
+      }
+      builders {
+        name: "flutter/try/Windows device_doctor"
       }
       retry_config {
         single_quota: 1


### PR DESCRIPTION
Reverts flutter/infra#456

With https://github.com/flutter/cocoon/pull/1222 - This will be unblocked (we must wait for it be submitted first though)